### PR TITLE
tm35-random-stones

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -36,6 +36,7 @@ const randomizer_exes = [_][]const u8{
     "tm35-rand-static",
     "tm35-rand-stats",
     "tm35-rand-wild",
+    "tm35-random-stones",
 };
 
 const other_exes = [_][]const u8{

--- a/src/common/unicode.zig
+++ b/src/common/unicode.zig
@@ -1,0 +1,87 @@
+const std = @import("std");
+
+const mem = std.mem;
+const unicode = std.unicode;
+
+/// Improved Utf8View which also keeps track of the length in codepoints
+pub const Utf8View = struct {
+    bytes: []const u8,
+    len: usize,
+
+    pub fn init(str: []const u8) !Utf8View {
+        return Utf8View{
+            .bytes = str,
+            .len = try utf8Len(str),
+        };
+    }
+
+    pub fn slice(view: Utf8View, start: usize, end: usize) Utf8View {
+        var len: usize = 0;
+        var i: usize = 0;
+        var it = view.iterator();
+        while (i < start) : (i += 1)
+            len += @boolToInt(it.nextCodepointSlice() != null);
+
+        const start_i = it.i;
+        while (i < end) : (i += 1)
+            len += @boolToInt(it.nextCodepointSlice() != null);
+
+        return .{
+            .bytes = view.bytes[start_i..it.i],
+            .len = len,
+        };
+    }
+
+    pub fn iterator(view: Utf8View) unicode.Utf8Iterator {
+        return unicode.Utf8View.initUnchecked(view.bytes).iterator();
+    }
+};
+
+/// Given a string of words, this function will split the string into lines where
+/// a maximum of `max_line_len` characters can occure on each line.
+pub fn splitIntoLines(allocator: *mem.Allocator, max_line_len: usize, string: Utf8View) !Utf8View {
+    var res = std.ArrayList(u8).init(allocator);
+    errdefer res.deinit();
+
+    // A decent estimate that will most likely ensure that we only do one allocation.
+    try res.ensureCapacity(string.len + (string.len / max_line_len) + 1);
+
+    var curr_line_len: usize = 0;
+    var it = mem.tokenize(string.bytes, " \n");
+    while (it.next()) |word_bytes| {
+        const word = Utf8View.init(word_bytes) catch unreachable;
+        const next_line_len = word.len + curr_line_len + (1 * @boolToInt(curr_line_len != 0));
+        if (next_line_len > max_line_len) {
+            try res.appendSlice("\n");
+            try res.appendSlice(word_bytes);
+            curr_line_len = word.len;
+        } else {
+            if (curr_line_len != 0)
+                try res.appendSlice(" ");
+            try res.appendSlice(word_bytes);
+            curr_line_len = next_line_len;
+        }
+    }
+
+    return Utf8View.init(res.toOwnedSlice()) catch unreachable;
+}
+
+fn utf8Len(s: []const u8) !usize {
+    var res: usize = 0;
+    var i: usize = 0;
+    while (i < s.len) : (res += 1) {
+        if (unicode.utf8ByteSequenceLength(s[i])) |cp_len| {
+            if (i + cp_len > s.len) {
+                return error.InvalidUtf8;
+            }
+
+            if (unicode.utf8Decode(s[i .. i + cp_len])) |_| {} else |_| {
+                return error.InvalidUtf8;
+            }
+            i += cp_len;
+        } else |err| {
+            return error.InvalidUtf8;
+        }
+    }
+    return res;
+}

--- a/src/common/util.zig
+++ b/src/common/util.zig
@@ -17,6 +17,7 @@ pub const exit = @import("exit.zig");
 pub const escape = @import("escape.zig");
 pub const parse = @import("parse.zig");
 pub const testing = @import("testing.zig");
+pub const unicode = @import("unicode.zig");
 
 pub const readLine = @import("readline.zig").readLine;
 
@@ -27,6 +28,7 @@ test "" {
     _ = parse;
     _ = readLine;
     _ = testing;
+    _ = unicode;
 }
 
 pub fn generateMain(
@@ -134,34 +136,6 @@ test "indexOfPtr" {
     for (arr) |*item, i| {
         std.testing.expectEqual(i, indexOfPtr(u8, arr, item));
     }
-}
-
-/// Given a string of words, this function will split the string into lines where
-/// a maximum of `max_line_len` characters can occure on each line.
-pub fn splitIntoLines(allocator: *mem.Allocator, max_line_len: usize, string: []const u8) ![]u8 {
-    var res = std.ArrayList(u8).init(allocator);
-    errdefer res.deinit();
-
-    // A decent estimate that will most likely ensure that we only do one allocation.
-    try res.ensureCapacity(string.len + (string.len / max_line_len) + 1);
-
-    var curr_line_len: usize = 0;
-    var it = mem.tokenize(string, " \n");
-    while (it.next()) |word| {
-        const next_line_len = word.len + curr_line_len + (1 * @boolToInt(curr_line_len != 0));
-        if (next_line_len > max_line_len) {
-            try res.appendSlice("\n");
-            try res.appendSlice(word);
-            curr_line_len = word.len;
-        } else {
-            if (curr_line_len != 0)
-                try res.appendSlice(" ");
-            try res.appendSlice(word);
-            curr_line_len = next_line_len;
-        }
-    }
-
-    return res.toOwnedSlice();
 }
 
 pub fn StackArrayList(comptime size: usize, comptime T: type) type {

--- a/src/core/gen3.zig
+++ b/src/core/gen3.zig
@@ -143,9 +143,10 @@ pub const PartyMemberBase = extern struct {
 
 pub const PartyMemberNone = extern struct {
     base: PartyMemberBase,
+    pad: lu16,
 
     comptime {
-        std.debug.assert(@sizeOf(@This()) == 6);
+        std.debug.assert(@sizeOf(@This()) == 8);
     }
 };
 

--- a/src/core/gen3.zig
+++ b/src/core/gen3.zig
@@ -506,14 +506,13 @@ pub const Game = struct {
 
     pub fn identify(stream: var) !offsets.Info {
         const header = try stream.readStruct(gba.Header);
-        try header.validate();
-
         for (offsets.infos) |info| {
             if (!mem.eql(u8, &info.game_title, &header.game_title))
                 continue;
             if (!mem.eql(u8, &info.gamecode, &header.gamecode))
                 continue;
 
+            try header.validate();
             return info;
         }
 

--- a/src/core/gen3/offsets.zig
+++ b/src/core/gen3/offsets.zig
@@ -74,6 +74,9 @@ pub const EvolutionSection = Section([5]gen3.Evolution);
 pub const LevelUpLearnsetPointerSection = Section(gen3.Ptr([*]gen3.LevelUpMove));
 pub const HmSection = Section(lu16);
 pub const TmSection = Section(lu16);
+pub const SpeciesToNationalDexSection = Section(lu16);
+pub const EmeraldPokedexSection = Section(gen3.EmeraldPokedexEntry);
+pub const RSFrLgPokedexSection = Section(gen3.RSFrLgPokedexEntry);
 pub const ItemSection = Section(gen3.Item);
 pub const WildPokemonHeaderSection = Section(gen3.WildPokemonHeader);
 pub const MapHeaderSection = Section(gen3.MapHeader);
@@ -102,6 +105,11 @@ pub const Info = struct {
     level_up_learnset_pointers: LevelUpLearnsetPointerSection,
     hms: HmSection,
     tms: TmSection,
+    pokedex: union {
+        rsfrlg: RSFrLgPokedexSection,
+        emerald: EmeraldPokedexSection,
+    },
+    species_to_national_dex: SpeciesToNationalDexSection,
     items: ItemSection,
     wild_pokemon_headers: WildPokemonHeaderSection,
     map_headers: MapHeaderSection,
@@ -155,6 +163,16 @@ const emerald_us_info = Info{
     .tms = .{
         .start = 6380436,
         .len = 50,
+    },
+    .pokedex = .{
+        .emerald = .{
+            .start = 5682608,
+            .len = 387,
+        },
+    },
+    .species_to_national_dex = .{
+        .start = 3267714,
+        .len = 411,
     },
     .items = .{
         .start = 5781920,
@@ -234,6 +252,16 @@ pub const fire_us_info = Info{
         .start = 4564484,
         .len = 50,
     },
+    .pokedex = .{
+        .rsfrlg = .{
+            .start = 4516016,
+            .len = 387,
+        },
+    },
+    .species_to_national_dex = .{
+        .start = 2433118,
+        .len = 411,
+    },
     .items = .{
         .start = 4042904,
         .len = 374,
@@ -311,6 +339,16 @@ pub const leaf_us_info = Info{
     .tms = .{
         .start = 4562996,
         .len = 50,
+    },
+    .pokedex = .{
+        .rsfrlg = .{
+            .start = 4514528,
+            .len = 387,
+        },
+    },
+    .species_to_national_dex = .{
+        .start = 2433082,
+        .len = 411,
     },
     .items = .{
         .start = 4042452,
@@ -390,6 +428,16 @@ pub const ruby_us_info = Info{
         .start = 3630364,
         .len = 50,
     },
+    .pokedex = .{
+        .rsfrlg = .{
+            .start = 3872884,
+            .len = 387,
+        },
+    },
+    .species_to_national_dex = .{
+        .start = 2082094,
+        .len = 411,
+    },
     .items = .{
         .start = 3954048,
         .len = 349,
@@ -467,6 +515,16 @@ pub const sapphire_us_info = Info{
     .tms = .{
         .start = 3630252,
         .len = 50,
+    },
+    .pokedex = .{
+        .rsfrlg = .{
+            .start = 3872976,
+            .len = 387,
+        },
+    },
+    .species_to_national_dex = .{
+        .start = 2081982,
+        .len = 411,
     },
     .items = .{
         .start = 3954140,

--- a/src/core/gen4.zig
+++ b/src/core/gen4.zig
@@ -516,15 +516,21 @@ pub const Game = struct {
     items: []Item,
     tms: []lu16,
     hms: []lu16,
-    static_pokemons: []*script.Command,
-    pokeball_items: []PokeballItem,
     evolutions: []EvolutionTable,
 
     level_up_moves: nds.fs.Fs,
     parties: nds.fs.Fs,
-    scripts: nds.fs.Fs,
-    text: nds.fs.Fs,
 
+    pokedex: nds.fs.Fs,
+    pokedex_heights: []lu32,
+    pokedex_weights: []lu32,
+    species_to_national_dex: []lu16,
+
+    scripts: nds.fs.Fs,
+    static_pokemons: []*script.Command,
+    pokeball_items: []PokeballItem,
+
+    text: nds.fs.Fs,
     pokemon_names: StringTable,
     trainer_names: StringTable,
     move_names: StringTable,
@@ -563,6 +569,7 @@ pub const Game = struct {
 
         const text = try getNarc(file_system, info.text);
         const scripts = try getNarc(file_system, info.scripts);
+        const pokedex = try getNarc(file_system, info.pokedex);
         const commands = try findScriptCommands(info.version, scripts, allocator);
         errdefer {
             allocator.free(commands.static_pokemons);
@@ -616,14 +623,20 @@ pub const Game = struct {
             },
             .tms = hm_tms[0..92],
             .hms = hm_tms[92..],
-            .static_pokemons = commands.static_pokemons,
-            .pokeball_items = commands.pokeball_items,
 
             .parties = try getNarc(file_system, info.parties),
             .level_up_moves = try getNarc(file_system, info.level_up_moves),
-            .scripts = scripts,
-            .text = text,
 
+            .pokedex = pokedex,
+            .pokedex_heights = mem.bytesAsSlice(lu32, pokedex.fileData(.{ .i = info.pokedex_heights })),
+            .pokedex_weights = mem.bytesAsSlice(lu32, pokedex.fileData(.{ .i = info.pokedex_weights })),
+            .species_to_national_dex = mem.bytesAsSlice(lu16, pokedex.fileData(.{ .i = info.species_to_national_dex })),
+
+            .scripts = scripts,
+            .static_pokemons = commands.static_pokemons,
+            .pokeball_items = commands.pokeball_items,
+
+            .text = text,
             .pokemon_names = StringTable{ .data = text.fileData(.{ .i = info.pokemon_names }) },
             .trainer_names = StringTable{ .data = text.fileData(.{ .i = info.trainer_names }) },
             .move_names = StringTable{ .data = text.fileData(.{ .i = info.move_names }) },

--- a/src/core/gen4/offsets.zig
+++ b/src/core/gen4/offsets.zig
@@ -27,6 +27,11 @@ pub const Info = struct {
     scripts: []const u8,
     itemdata: []const u8,
 
+    pokedex: []const u8,
+    pokedex_heights: u16,
+    pokedex_weights: u16,
+    species_to_national_dex: u16,
+
     text: []const u8,
     pokemon_names: u16,
     trainer_names: u16,
@@ -63,6 +68,11 @@ const hg_info = Info{
     .scripts = "/a/0/1/2",
     .itemdata = "/a/0/1/7",
 
+    .pokedex = "/a/0/7/4",
+    .pokedex_heights = 0,
+    .pokedex_weights = 1,
+    .species_to_national_dex = 11,
+
     .text = "/a/0/2/7",
     .pokemon_names = 237,
     .trainer_names = 729,
@@ -90,6 +100,11 @@ const ss_info = Info{
     .wild_pokemons = "/a/1/3/6",
     .scripts = hg_info.scripts,
     .itemdata = hg_info.itemdata,
+
+    .pokedex = hg_info.pokedex,
+    .pokedex_heights = hg_info.pokedex_heights,
+    .pokedex_weights = hg_info.pokedex_weights,
+    .species_to_national_dex = hg_info.species_to_national_dex,
 
     .text = hg_info.text,
     .pokemon_names = hg_info.pokemon_names,
@@ -124,6 +139,11 @@ const diamond_info = Info{
     .scripts = "/fielddata/script/scr_seq_release.narc",
     .itemdata = "/itemtool/itemdata/item_data.narc",
 
+    .pokedex = "application/zukanlist/zkn_data/zukan_data.narc",
+    .pokedex_heights = 0,
+    .pokedex_weights = 1,
+    .species_to_national_dex = 11,
+
     .text = "/msgdata/msg.narc",
     .pokemon_names = 362,
     .trainer_names = 559,
@@ -151,6 +171,11 @@ const pearl_info = Info{
     .wild_pokemons = "/fielddata/encountdata/p_enc_data.narc",
     .scripts = diamond_info.scripts,
     .itemdata = diamond_info.itemdata,
+
+    .pokedex = diamond_info.pokedex,
+    .pokedex_heights = diamond_info.pokedex_heights,
+    .pokedex_weights = diamond_info.pokedex_weights,
+    .species_to_national_dex = diamond_info.species_to_national_dex,
 
     .text = diamond_info.text,
     .pokemon_names = diamond_info.pokemon_names,
@@ -184,6 +209,11 @@ const platinum_info = Info{
     .wild_pokemons = "/fielddata/encountdata/pl_enc_data.narc",
     .scripts = "/fielddata/script/scr_seq.narc",
     .itemdata = "/itemtool/itemdata/pl_item_data.narc",
+
+    .pokedex = "application/zukanlist/zkn_data/zukan_data_gira.narc",
+    .pokedex_heights = 0,
+    .pokedex_weights = 1,
+    .species_to_national_dex = 11,
 
     .text = "/msgdata/pl_msg.narc",
     .pokemon_names = 412,

--- a/src/core/gen5/offsets.zig
+++ b/src/core/gen5/offsets.zig
@@ -23,11 +23,13 @@ pub const Info = struct {
 
     text: []const u8,
     pokemon_names: u16,
+    pokedex_category_names: u16,
     trainer_names: u16,
     move_names: u16,
     move_descriptions: u16,
     ability_names: u16,
     item_names: u16,
+    item_names_on_the_ground: u16,
     item_descriptions: u16,
     type_names: u16,
 };
@@ -73,11 +75,13 @@ const black2_info = Info{
 
     .text = "a/0/0/2",
     .pokemon_names = 90,
+    .pokedex_category_names = 464,
     .trainer_names = 382,
     .move_names = 403,
     .move_descriptions = 402,
     .ability_names = 374,
     .item_names = 64,
+    .item_names_on_the_ground = 481,
     .item_descriptions = 63,
     .type_names = 489,
 };
@@ -100,11 +104,13 @@ const white2_info = Info{
 
     .text = black2_info.text,
     .pokemon_names = black2_info.pokemon_names,
+    .pokedex_category_names = black2_info.pokedex_category_names,
     .trainer_names = black2_info.trainer_names,
     .move_names = black2_info.move_names,
     .move_descriptions = black2_info.move_descriptions,
     .ability_names = black2_info.ability_names,
     .item_names = black2_info.item_names,
+    .item_names_on_the_ground = black2_info.item_names_on_the_ground,
     .item_descriptions = black2_info.item_descriptions,
     .type_names = black2_info.type_names,
 };
@@ -152,11 +158,13 @@ const black_info = Info{
 
     .text = black2_info.text,
     .pokemon_names = 70,
+    .pokedex_category_names = 260,
     .trainer_names = 190,
     .move_names = 203,
     .move_descriptions = 202,
     .ability_names = 182,
     .item_names = 54,
+    .item_names_on_the_ground = 279,
     .item_descriptions = 53,
     .type_names = 287,
 };
@@ -176,13 +184,16 @@ const white_info = Info{
     .parties = black_info.parties,
     .wild_pokemons = black_info.wild_pokemons,
     .itemdata = black_info.itemdata,
+
     .text = black_info.text,
     .pokemon_names = black_info.pokemon_names,
+    .pokedex_category_names = black_info.pokedex_category_names,
     .trainer_names = black_info.trainer_names,
     .move_names = black_info.move_names,
     .move_descriptions = black_info.move_descriptions,
     .ability_names = black_info.ability_names,
     .item_names = black_info.item_names,
+    .item_names_on_the_ground = black_info.item_names_on_the_ground,
     .item_descriptions = black_info.item_descriptions,
     .type_names = black_info.type_names,
 };

--- a/src/core/tm35-apply.zig
+++ b/src/core/tm35-apply.zig
@@ -1170,19 +1170,10 @@ fn applyGen5(nds_rom: nds.Rom, game: gen5.Game, line: usize, str: []const u8) !v
 }
 
 fn applyGen5String(table: gen5.StringTable, index: usize, value: []const u8) !void {
-    const escapes = comptime blk: {
-        var res: [255][]const u8 = undefined;
-        mem.copy([]const u8, res[0..], &escape.default_escapes);
-        res['\r'] = "\\r";
-        res['\n'] = "\\n";
-        res['\\'] = "\\\\";
-        break :blk res;
-    };
-
     if (index >= table.entryCount(0))
         return error.Error;
     var stream = io.bufferedOutStream(table.getStringStream(0, index).outStream());
-    try escape.writeUnEscaped(stream.outStream(), value, escapes);
+    try escape.writeUnEscaped(stream.outStream(), value, escape.zig_escapes);
     try stream.outStream().writeAll("\xff\xff");
     try stream.flush();
 }

--- a/src/core/tm35-apply.zig
+++ b/src/core/tm35-apply.zig
@@ -364,6 +364,11 @@ fn applyGen3(game: gen3.Game, line: usize, str: []const u8) !void {
                 c("battle_usage") => item.battle_usage = try parser.parse(parselu32v),
                 c("secondary_id") => item.secondary_id = try parser.parse(parselu32v),
                 c("name") => try gen3.encodings.encode(.en_us, try parser.parse(parse.strv), &item.name),
+                c("description") => {
+                    const desc_small = try item.description.toSliceZ(game.data);
+                    const description = try item.description.toSlice(game.data, desc_small.len + 1);
+                    try gen3.encodings.encode(.en_us, try parser.parse(parse.strv), description);
+                },
                 c("pocket") => switch (game.version) {
                     .ruby, .sapphire, .emerald => item.pocket = gen3.Pocket{ .rse = try parser.parse(comptime parse.enumv(gen3.RSEPocket)) },
                     .fire_red, .leaf_green => item.pocket = gen3.Pocket{ .frlg = try parser.parse(comptime parse.enumv(gen3.FRLGPocket)) },

--- a/src/core/tm35-apply.zig
+++ b/src/core/tm35-apply.zig
@@ -27,6 +27,7 @@ const escape = util.escape;
 const exit = util.exit;
 const parse = util.parse;
 
+const li16 = rom.int.li16;
 const lu16 = rom.int.lu16;
 const lu32 = rom.int.lu32;
 const lu64 = rom.int.lu64;
@@ -169,6 +170,7 @@ pub fn toInt(
     }.func;
 }
 
+pub const parseli16v = parse.value(li16, toInt(i16, .Little));
 pub const parselu16v = parse.value(lu16, toInt(u16, .Little));
 pub const parselu32v = parse.value(lu32, toInt(u32, .Little));
 pub const parselu64v = parse.value(lu64, toInt(u64, .Little));
@@ -375,6 +377,46 @@ fn applyGen3(game: gen3.Game, line: usize, str: []const u8) !void {
                     else => unreachable,
                 },
                 else => return error.NoField,
+            }
+        },
+        c("pokedex") => {
+            const index = try parser.parse(parse.index);
+            switch (game.version) {
+                .emerald => {
+                    if (index >= game.pokedex.emerald.len)
+                        return error.Error;
+                    const entry = &game.pokedex.emerald[index];
+
+                    switch (m(try parser.parse(parse.anyField))) {
+                        c("height") => entry.height = try parser.parse(parselu16v),
+                        c("weight") => entry.weight = try parser.parse(parselu16v),
+                        c("pokemon_scale") => entry.pokemon_scale = try parser.parse(parselu16v),
+                        c("pokemon_offset") => entry.pokemon_offset = try parser.parse(parseli16v),
+                        c("trainer_scale") => entry.trainer_scale = try parser.parse(parselu16v),
+                        c("trainer_offset") => entry.trainer_offset = try parser.parse(parseli16v),
+                        else => return error.NoField,
+                    }
+                },
+                .ruby,
+                .sapphire,
+                .fire_red,
+                .leaf_green,
+                => {
+                    if (index >= game.pokedex.rsfrlg.len)
+                        return error.Error;
+                    const entry = &game.pokedex.rsfrlg[index];
+
+                    switch (m(try parser.parse(parse.anyField))) {
+                        c("height") => entry.height = try parser.parse(parselu16v),
+                        c("weight") => entry.weight = try parser.parse(parselu16v),
+                        c("pokemon_scale") => entry.pokemon_scale = try parser.parse(parselu16v),
+                        c("pokemon_offset") => entry.pokemon_offset = try parser.parse(parseli16v),
+                        c("trainer_scale") => entry.trainer_scale = try parser.parse(parselu16v),
+                        c("trainer_offset") => entry.trainer_offset = try parser.parse(parseli16v),
+                        else => return error.NoField,
+                    }
+                },
+                else => unreachable,
             }
         },
         c("abilities") => {

--- a/src/core/tm35-gen3-offsets.zig
+++ b/src/core/tm35-gen3-offsets.zig
@@ -491,7 +491,7 @@ test "searcher.Searcher.find" {
         a: u16,
         b: u32,
     };
-    const s_array = &[_]S{
+    var s_array = [_]S{
         S{ .a = 0, .b = 1 },
         S{ .a = 2, .b = 3 },
     };
@@ -513,7 +513,7 @@ test "searcher.Searcher.find2" {
         a: u16,
         b: u32,
     };
-    const s_array = &[_]S{
+    var s_array = [_]S{
         S{ .a = 4, .b = 1 },
         S{ .a = 0, .b = 3 },
         S{ .a = 4, .b = 1 },
@@ -547,7 +547,7 @@ test "searcher.Searcher.find3" {
         a: u16,
         b: u32,
     };
-    const s_array = &[_]S{
+    var s_array = [_]S{
         S{ .a = 4, .b = 1 },
         S{ .a = 0, .b = 3 },
         S{ .a = 4, .b = 1 },
@@ -580,7 +580,7 @@ test "searcher.Searcher.find4" {
         a: u16,
         b: u32,
     };
-    const s_array = &[_]S{
+    var s_array = [_]S{
         S{ .a = 4, .b = 1 },
         S{ .a = 0, .b = 3 },
         S{ .a = 4, .b = 1 },
@@ -596,23 +596,23 @@ test "searcher.Searcher.find4" {
         &[_][]const u8{"b"},
     });
 
-    const a = &[_]S{
+    const a = [_]S{
         S{ .a = 4, .b = 3 },
         S{ .a = 0, .b = 1 },
     };
-    const b = &[_]S{
+    const b = [_]S{
         S{ .a = 0, .b = 1 },
         S{ .a = 4, .b = 3 },
     };
     testing.expectEqualSlices(
         u8,
         mem.sliceAsBytes(s_array[1..6]),
-        mem.sliceAsBytes(try S1.find4(data, a, b)),
+        mem.sliceAsBytes(try S1.find4(data, &a, &b)),
     );
     testing.expectEqualSlices(
         u8,
         mem.sliceAsBytes(s_array[0..5]),
-        mem.sliceAsBytes(try S2.find4(data, a, b)),
+        mem.sliceAsBytes(try S2.find4(data, &a, &b)),
     );
 }
 

--- a/src/core/tm35-load.zig
+++ b/src/core/tm35-load.zig
@@ -984,7 +984,7 @@ fn outputGen5Data(nds_rom: nds.Rom, game: gen5.Game, stream: var) !void {
     try outputGen5StringTable(stream, "moves", "description", game.move_descriptions);
     try outputGen5StringTable(stream, "abilities", "name", game.ability_names);
     try outputGen5StringTable(stream, "items", "name", game.item_names);
-    //try outputGen5StringTable(stream, "items", "name_on_the_ground", game.item_names_on_the_ground);
+    //try outputGen5StringTable(stream, "items", "name_on_ground", game.item_names_on_the_ground);
     try outputGen5StringTable(stream, "items", "description", game.item_descriptions);
     try outputGen5StringTable(stream, "types", "name", game.type_names);
 

--- a/src/core/tm35-load.zig
+++ b/src/core/tm35-load.zig
@@ -287,6 +287,11 @@ fn outputGen3Data(game: gen3.Game, stream: var) !void {
         try stream.print(".items[{}].price={}\n", .{ i, item.price.value() });
         try stream.print(".items[{}].hold_effect={}\n", .{ i, item.hold_effect });
         try stream.print(".items[{}].hold_effect_par={}\n", .{ i, item.hold_effect_param });
+        if (item.description.toSliceZ(game.data)) |description| {
+            try stream.print(".items[{}].description=", .{i});
+            try gen3.encodings.decode(.en_us, description, stream);
+            try stream.writeByte('\n');
+        } else |_| {}
         // try stream.print(".items[{}].description={}\n", .{i, item.description});
         try stream.print(".items[{}].importance={}\n", .{ i, item.importance });
         // try stream.print(".items[{}].unknown={}\n", .{i, item.unknown});

--- a/src/core/tm35-load.zig
+++ b/src/core/tm35-load.zig
@@ -720,7 +720,6 @@ fn outputGen5Data(nds_rom: nds.Rom, game: gen5.Game, stream: var) !void {
 
     for (game.trainers) |trainer, index| {
         const i = index + 1;
-        try stream.print(".trainers[{}].party_type={}\n", .{ i, @enumToInt(trainer.party_type) });
         try stream.print(".trainers[{}].class={}\n", .{ i, trainer.class });
         try stream.print(".trainers[{}].battle_type={}\n", .{ i, trainer.battle_type });
 

--- a/src/core/tm35-load.zig
+++ b/src/core/tm35-load.zig
@@ -1005,21 +1005,12 @@ fn outputGen5StringTable(
     field_name: []const u8,
     est: gen5.StringTable,
 ) !void {
-    const escapes = comptime blk: {
-        var res: [255][]const u8 = undefined;
-        mem.copy([]const u8, res[0..], &escape.default_escapes);
-        res['\r'] = "\\r";
-        res['\n'] = "\\n";
-        res['\\'] = "\\\\";
-        break :blk res;
-    };
-
     var buf: [1024]u8 = undefined;
     var i: u32 = 0;
     while (i < est.entryCount(0)) : (i += 1) {
         try stream.print(".{}[{}].{}=", .{ array_name, i, field_name });
         const len = try est.getStringStream(0, i).inStream().readAll(&buf);
-        try escape.writeEscaped(stream, buf[0..len], escapes);
+        try escape.writeEscaped(stream, buf[0..len], escape.zig_escapes);
         try stream.writeAll("\n");
     }
 }

--- a/src/core/tm35-load.zig
+++ b/src/core/tm35-load.zig
@@ -303,6 +303,35 @@ fn outputGen3Data(game: gen3.Game, stream: var) !void {
         try stream.print(".items[{}].secondary_id={}\n", .{ i, item.secondary_id.value() });
     }
 
+    switch (game.version) {
+        .emerald => for (game.pokedex.emerald) |entry, i| {
+            //try stream.print(".pokedex[{}].category_name={}\n", .{ i, entry.category_name});
+            try stream.print(".pokedex[{}].height={}\n", .{ i, entry.height.value() });
+            try stream.print(".pokedex[{}].weight={}\n", .{ i, entry.weight.value() });
+            //try stream.print(".pokedex[{}].description={}\n", .{ i, entry.description});
+            try stream.print(".pokedex[{}].pokemon_scale={}\n", .{ i, entry.pokemon_scale.value() });
+            try stream.print(".pokedex[{}].pokemon_offset={}\n", .{ i, entry.pokemon_offset.value() });
+            try stream.print(".pokedex[{}].trainer_scale={}\n", .{ i, entry.trainer_scale.value() });
+            try stream.print(".pokedex[{}].trainer_offset={}\n", .{ i, entry.trainer_offset.value() });
+        },
+        .ruby,
+        .sapphire,
+        .fire_red,
+        .leaf_green,
+        => for (game.pokedex.rsfrlg) |entry, i| {
+            //try stream.print(".pokedex[{}].category_name={}\n", .{ i, entry.category_name});
+            try stream.print(".pokedex[{}].height={}\n", .{ i, entry.height.value() });
+            try stream.print(".pokedex[{}].weight={}\n", .{ i, entry.weight.value() });
+            //try stream.print(".pokedex[{}].description={}\n", .{ i, entry.description});
+            //try stream.print(".pokedex[{}].unused_description={}\n", .{ i, entry.unused_description});
+            try stream.print(".pokedex[{}].pokemon_scale={}\n", .{ i, entry.pokemon_scale.value() });
+            try stream.print(".pokedex[{}].pokemon_offset={}\n", .{ i, entry.pokemon_offset.value() });
+            try stream.print(".pokedex[{}].trainer_scale={}\n", .{ i, entry.trainer_scale.value() });
+            try stream.print(".pokedex[{}].trainer_offset={}\n", .{ i, entry.trainer_offset.value() });
+        },
+        else => unreachable,
+    }
+
     for (game.wild_pokemon_headers) |header, i| {
         if (header.land.toPtr(game.data)) |land| {
             const wilds = try land.wild_pokemons.toPtr(game.data);

--- a/src/gui/tm35-randomizer.zig
+++ b/src/gui/tm35-randomizer.zig
@@ -1091,6 +1091,7 @@ const default_commands = //
     "tm35-rand-starters" ++ extension ++ "\n" ++
     "tm35-rand-static" ++ extension ++ "\n" ++
     "tm35-rand-wild" ++ extension ++ "\n" ++
+    "tm35-random-stones" ++ extension ++ "\n" ++
     "tm35-no-trade-evolutions" ++ extension ++ "\n" ++
     "tm35-generate-site" ++ extension ++ "\n";
 

--- a/src/gui/tm35-randomizer.zig
+++ b/src/gui/tm35-randomizer.zig
@@ -559,8 +559,7 @@ pub fn drawActions(
             };
         },
         .save_settings => {
-            // TODO: Warn if the user tries to overwrite existing file.
-            const file = fs.cwd().openFile(selected_path.toSliceConst(), .{ .write = true }) catch |err| {
+            const file = fs.cwd().createFile(selected_path.toSliceConst(), .{}) catch |err| {
                 popups.err("Could not open '{}': {}", .{ selected_path.toSliceConst(), err });
                 return rom;
             };
@@ -1037,12 +1036,8 @@ const Settings = struct {
                 .params = command.params,
             };
 
-            // TODO: Better error returned
             while (try streaming_clap.next()) |arg| {
                 const param_i = util.indexOfPtr(clap.Param(clap.Help), command.params, arg.param);
-                if (command_args[param_i].len != 0)
-                    return error.DuplicateParam;
-
                 const command_arg = &command_args[param_i];
 
                 if (arg.value) |value| {

--- a/src/randomizers/tm35-rand-pokeball-items.zig
+++ b/src/randomizers/tm35-rand-pokeball-items.zig
@@ -36,7 +36,7 @@ fn usage(stream: var) !void {
     try stream.writeAll("Usage: tm35-rand-pokeball-items ");
     try clap.usage(stream, &params);
     try stream.writeAll("\nRandomizes the items found in pokeballs lying around. " ++
-        "Only works properly for dppt and b2w2.\n" ++
+        "Only works properly for all gen3 games, dppt and b2w2.\n" ++
         "\n" ++
         "Options:\n");
     try clap.help(stream, &params);

--- a/src/randomizers/tm35-rand-static.zig
+++ b/src/randomizers/tm35-rand-static.zig
@@ -36,7 +36,7 @@ fn usage(stream: var) !void {
     try stream.writeAll("Usage: tm35-rand-starters ");
     try clap.usage(stream, &params);
     try stream.writeAll("\nRandomizes static Pokémons. Only works properly " ++
-        "for dppt and b2w2.\n" ++
+        "for all gen3 games, dppt and b2w2.\n" ++
         "\n" ++
         "Options:\n");
     try clap.help(stream, &params);

--- a/src/randomizers/tm35-random-stones.zig
+++ b/src/randomizers/tm35-random-stones.zig
@@ -539,7 +539,7 @@ fn randomize(allocator: *mem.Allocator, data: *Data, seed: usize) !void {
         };
     }
 
-    const num_pokemons = data.pokemons.count();
+    const num_pokemons = species.count();
     for (species.span()) |s_range| {
         var pokemon_id: usize = s_range.start;
         while (pokemon_id <= s_range.end) : (pokemon_id += 1) {
@@ -552,7 +552,7 @@ fn randomize(allocator: *mem.Allocator, data: *Data, seed: usize) !void {
                 const item_id = stones.at(stone);
                 const pick = switch (stone) {
                     chance_stone => while (num_pokemons > 1) {
-                        const pick = random.intRangeLessThan(usize, 0, num_pokemons);
+                        const pick = species.at(random.intRangeLessThan(usize, 0, num_pokemons));
                         if (pick != pokemon_id)
                             break pick;
                     } else pokemon_id,

--- a/src/randomizers/tm35-random-stones.zig
+++ b/src/randomizers/tm35-random-stones.zig
@@ -1,0 +1,676 @@
+const clap = @import("clap");
+const std = @import("std");
+const util = @import("util");
+
+const debug = std.debug;
+const fmt = std.fmt;
+const fs = std.fs;
+const heap = std.heap;
+const io = std.io;
+const math = std.math;
+const mem = std.mem;
+const os = std.os;
+const rand = std.rand;
+const testing = std.testing;
+
+const exit = util.exit;
+const parse = util.parse;
+
+const Clap = clap.ComptimeClap(clap.Help, &params);
+const Param = clap.Param(clap.Help);
+
+pub const main = util.generateMain("0.0.0", main2, &params, usage);
+
+const params = blk: {
+    @setEvalBranchQuota(100000);
+    break :blk [_]Param{
+        clap.parseParam("-h, --help                 Display this help text and exit.                                                          ") catch unreachable,
+        clap.parseParam("-r, --replace-cheap-items  Replaces cheap items in pokeballs with stones.") catch unreachable,
+        clap.parseParam("-s, --seed <NUM>           The seed to use for random numbers. A random seed will be picked if this is not specified.") catch unreachable,
+        clap.parseParam("-v, --version              Output version information and exit.                                                      ") catch unreachable,
+    };
+};
+
+fn usage(stream: var) !void {
+    try stream.writeAll("Usage: tm35-random-stones ");
+    try clap.usage(stream, &params);
+    try stream.writeAll("\nChanges all Pokémons to evolve using new evolution stones. " ++
+        "These stones evolve a Pokémon to a random new Pokémon that upholds the " ++
+        "requirements of the stone. Here is a list of all stones:\n" ++
+        "* Chance Stone: Evolves a Pokémon into random Pokémon.\n" ++
+        "* Superior Stone: Evolves a Pokémon into random Pokémon with better overall stats.\n" ++
+        "* Poor Stone: Evolves a Pokémon into random Pokémon with worse overall stats.\n" ++
+        "* Form Stone: Evolves a Pokémon into random Pokémon with a common type.\n" ++
+        "* Skill Stone: Evolves a Pokémon into random Pokémon with a common ability.\n" ++
+        "* Breed Stone: Evolves a Pokémon into random Pokémon in the same egg group.\n" ++
+        "* Buddy Stone: Evolves a Pokémon into random Pokémon with the same base friendship.\n" ++
+        "\n" ++
+        "This command will try to get as many of these stones into the game as possible, " ++
+        "but beware, that all stones might not exist. Also beware, that the stones might " ++
+        "have different (but simular) names in cases wherethe game does not support long " ++
+        "item names.\n" ++
+        "\n" ++
+        "Options:\n");
+    try clap.help(stream, &params);
+}
+
+/// TODO: This function actually expects an allocator that owns all the memory allocated, such
+///       as ArenaAllocator or FixedBufferAllocator. Can we either make this requirement explicit
+///       or move the Arena into this function?
+pub fn main2(
+    allocator: *mem.Allocator,
+    comptime InStream: type,
+    comptime OutStream: type,
+    stdio: util.CustomStdIoStreams(InStream, OutStream),
+    args: var,
+) u8 {
+    const replace_cheap = args.flag("--replace-cheap-items");
+    const seed = if (args.option("--seed")) |seed|
+        fmt.parseUnsigned(u64, seed, 10) catch |err| {
+            stdio.err.print("'{}' could not be parsed as a number to --seed: {}\n", .{ seed, err }) catch {};
+            usage(stdio.err) catch {};
+            return 1;
+        }
+    else blk: {
+        var buf: [8]u8 = undefined;
+        os.getrandom(buf[0..]) catch break :blk @as(u64, 0);
+        break :blk mem.readInt(u64, &buf, .Little);
+    };
+
+    var line_buf = std.ArrayList(u8).init(allocator);
+    var stdin = io.bufferedInStream(stdio.in);
+    var data = Data{
+        .strings = std.StringHashMap(usize).init(allocator),
+    };
+
+    while (util.readLine(&stdin, &line_buf) catch |err| return exit.stdinErr(stdio.err, err)) |line| {
+        const str = mem.trimRight(u8, line, "\r\n");
+        const print_line = parseLine(allocator, &data, replace_cheap, str) catch |err| switch (err) {
+            error.OutOfMemory => return exit.allocErr(stdio.err),
+            error.ParseError => true,
+        };
+        if (print_line)
+            stdio.out.print("{}\n", .{str}) catch |err| return exit.stdoutErr(stdio.err, err);
+
+        line_buf.resize(0) catch unreachable;
+    }
+
+    randomize(allocator, &data, seed) catch return exit.allocErr(stdio.err);
+
+    for (data.pokemons.values()) |pokemon, i| {
+        const pokemon_id = data.pokemons.at(i).key;
+        for (pokemon.evos.values()) |evo, j| {
+            const evo_id = pokemon.evos.at(j).key;
+            stdio.out.print(".pokemons[{}].evos[{}].method=use_item\n", .{ pokemon_id, evo_id }) catch |err| return exit.stdoutErr(stdio.err, err);
+            stdio.out.print(".pokemons[{}].evos[{}].param={}\n", .{ pokemon_id, evo_id, evo.item }) catch |err| return exit.stdoutErr(stdio.err, err);
+            stdio.out.print(".pokemons[{}].evos[{}].target={}\n", .{ pokemon_id, evo_id, evo.target }) catch |err| return exit.stdoutErr(stdio.err, err);
+        }
+    }
+    for (data.items.values()) |item, i| {
+        const item_id = data.items.at(i).key;
+        if (item.name.len != 0)
+            stdio.out.print(".items[{}].name={}\n", .{ item_id, item.name }) catch |err| return exit.stdoutErr(stdio.err, err);
+        if (item.description.len != 0)
+            stdio.out.print(".items[{}].description={}\n", .{ item_id, item.description }) catch |err| return exit.stdoutErr(stdio.err, err);
+    }
+    for (data.pokeball_items.values()) |item, i| {
+        const ball_id = data.pokeball_items.at(i).key;
+        stdio.out.print(".pokeball_items[{}].item={}\n", .{ ball_id, item }) catch |err| return exit.stdoutErr(stdio.err, err);
+    }
+    return 0;
+}
+
+fn parseLine(allocator: *mem.Allocator, data: *Data, replace_cheap: bool, str: []const u8) !bool {
+    const sw = parse.Swhash(16);
+    const m = sw.match;
+    const c = sw.case;
+
+    const unknown_method = try data.string("????");
+
+    var p = parse.MutParser{ .str = str };
+    switch (m(try p.parse(parse.anyField))) {
+        c("pokemons") => {
+            const index = try p.parse(parse.index);
+            const pokemon = try data.pokemons.getOrPutValue(allocator, index, Pokemon{});
+
+            switch (m(try p.parse(parse.anyField))) {
+                c("stats") => switch (m(try p.parse(parse.anyField))) {
+                    c("hp") => pokemon.stats[0] = try p.parse(parse.u8v),
+                    c("attack") => pokemon.stats[1] = try p.parse(parse.u8v),
+                    c("defense") => pokemon.stats[2] = try p.parse(parse.u8v),
+                    c("speed") => pokemon.stats[3] = try p.parse(parse.u8v),
+                    c("sp_attack") => pokemon.stats[4] = try p.parse(parse.u8v),
+                    c("sp_defense") => pokemon.stats[5] = try p.parse(parse.u8v),
+                    else => return true,
+                },
+                c("types") => {
+                    _ = try p.parse(parse.index);
+                    const t = try p.parse(parse.usizev);
+                    const set = try data.pokemons_by_type.getOrPutValue(allocator, t, Set{});
+                    _ = try set.put(allocator, index);
+                    _ = try pokemon.types.put(allocator, t);
+                },
+                c("abilities") => {
+                    _ = try p.parse(parse.index);
+                    const ability = try p.parse(parse.usizev);
+                    const set = try data.pokemons_by_ability.getOrPutValue(allocator, ability, Set{});
+                    _ = try set.put(allocator, index);
+                    _ = try pokemon.abilities.put(allocator, ability);
+                },
+                c("egg_groups") => {
+                    _ = try p.parse(parse.index);
+                    const group = try data.string(try p.parse(parse.strv));
+                    const set = try data.pokemons_by_egg_group.getOrPutValue(allocator, group, Set{});
+                    _ = try set.put(allocator, index);
+                    _ = try pokemon.egg_groups.put(allocator, group);
+                },
+                c("base_friendship") => {
+                    const friendship = try p.parse(parse.usizev);
+                    const set = try data.pokemons_by_base_friendship.getOrPutValue(allocator, friendship, Set{});
+                    _ = try set.put(allocator, index);
+                    pokemon.base_friendship = friendship;
+                },
+                c("evos") => {
+                    const evo_index = try p.parse(parse.index);
+                    data.max_evolutions = math.max(data.max_evolutions, evo_index + 1);
+
+                    const evo = try pokemon.evos.getOrPutValue(allocator, evo_index, Evolution{
+                        .method = unknown_method,
+                    });
+                    switch (m(try p.parse(parse.anyField))) {
+                        c("target") => evo.target = try p.parse(parse.usizev),
+                        c("param") => evo.item = try p.parse(parse.usizev),
+                        c("method") => evo.method = try data.string(try p.parse(parse.strv)),
+                        else => {},
+                    }
+                    return false;
+                },
+                else => return true,
+            }
+            return true;
+        },
+        c("items") => {
+            const index = try p.parse(parse.index);
+            const item = try data.items.getOrPutValue(allocator, index, Item{});
+
+            switch (m(try p.parse(parse.anyField))) {
+                c("name") => item.name = try mem.dupe(allocator, u8, try p.parse(parse.strv)),
+                c("description") => item.description = try mem.dupe(allocator, u8, try p.parse(parse.strv)),
+                c("price") => {
+                    item.price = try p.parse(parse.usizev);
+                    return true;
+                },
+                else => return true,
+            }
+            return false;
+        },
+        c("pokeball_items") => if (replace_cheap) {
+            const index = try p.parse(parse.index);
+            _ = try p.parse(comptime parse.field("item"));
+            _ = try data.pokeball_items.put(allocator, index, try p.parse(parse.usizev));
+            return false;
+        },
+        else => return true,
+    }
+    return true;
+}
+
+fn randomize(allocator: *mem.Allocator, data: *Data, seed: usize) !void {
+    const random = &rand.DefaultPrng.init(seed).random;
+    const use_item_method = try data.string("use_item");
+
+    // First, let's find items that are used for evolving Pokémons.
+    // We will use these items as our stones.
+    var stones = Set{};
+    for (data.pokemons.values()) |*pokemon| {
+        for (pokemon.evos.values()) |evo| {
+            if (evo.method == use_item_method)
+                _ = try stones.put(allocator, evo.item);
+        }
+
+        // Reset evolutions. We don't need the old anymore.
+        pokemon.evos.deinit(allocator);
+        pokemon.evos = Evolutions{};
+    }
+
+    debug.warn("{}\n", .{stones.count()});
+
+    // Make a map from total stats to the Pokémons who have them. This couldn't
+    // be done during the parsing of the data as we need all the stats to perform
+    // the sum. It is therefor done here.
+    var pokemons_by_stats = PokemonBy{};
+    for (data.pokemons.values()) |pokemon, i| {
+        const id = data.pokemons.at(i).key;
+        const set = try pokemons_by_stats.getOrPutValue(allocator, sum(&pokemon.stats), Set{});
+        _ = try set.put(allocator, id);
+    }
+
+    // Make sure these indexs line up with the array below
+    const chance_stone = 0;
+    const superior_stone = 1;
+    const poor_stone = 2;
+    const form_stone = 3;
+    const skill_stone = 4;
+    const breed_stone = 5;
+    const buddy_stone = 6;
+    const stone_strings = [_]struct {
+        names: []const []const u8,
+        descriptions: []const []const u8,
+    }{
+        .{
+            .names = &[_][]const u8{
+                "Chance Stone",
+                "Chance Rock",
+                "Luck Rock",
+                "Luck Rck",
+                "C Stone",
+                "C Rock",
+                "C Rck",
+            },
+            .descriptions = &[_][]const u8{
+                "Evolves a Pokémon into random Pokémon.",
+                "Evolves a Pokémon into random Pokémon",
+                "Evolve a Pokémon into random Pokémon",
+                "Evolves a Pokémon to random Pokémon",
+                "Evolve a Pokémon to random Pokémon",
+                "Evolves to random Pokémon",
+                "Evolve to random Pokémon",
+                "Into random Pokémon",
+                "To random Pokémon",
+                "Random Pokémon",
+            },
+        },
+        .{
+            .names = &[_][]const u8{
+                "Superior Stone",
+                "Superior Rock",
+                "Better Stone",
+                "Better Rock",
+                "Good Stone",
+                "Good Rock",
+                "Good Rck",
+                "B Stone",
+                "B Rock",
+                "B Rck",
+            },
+            .descriptions = &[_][]const u8{
+                "Evolves a Pokémon into random Pokémon with better overall stats.",
+                "Evolves a Pokémon into random Pokémon with better overall stats",
+                "Evolves a Pokémon into random Pokémon with better stats",
+                "Evolve a Pokémon into random Pokémon with better stats",
+                "Evolves a Pokémon to random Pokémon with better stats",
+                "Evolve a Pokémon to random Pokémon with better stats",
+                "Evolves to random Pokémon with better stats",
+                "Evolve to random Pokémon with better stats",
+                "Into random Pokémon with better stats",
+                "To random Pokémon with better stats",
+                "Random Pokémon with better stats",
+                "Random Pokémon, better stats",
+                "Random Pokémon better stats",
+                "Random, better stats",
+                "Random better stats",
+                "Better stats",
+            },
+        },
+        .{
+            .names = &[_][]const u8{
+                "Poor Stone",
+                "Poor Rock",
+                "Bad Rock",
+                "Bad Rck",
+            },
+            .descriptions = &[_][]const u8{
+                "Evolves a Pokémon into random Pokémon with worse overall stats.",
+                "Evolves a Pokémon into random Pokémon with worse overall stats",
+                "Evolves a Pokémon into random Pokémon with worse stats",
+                "Evolve a Pokémon into random Pokémon with worse stats",
+                "Evolves a Pokémon to random Pokémon with worse stats",
+                "Evolve a Pokémon to random Pokémon with worse stats",
+                "Evolves to random Pokémon with worse stats",
+                "Evolve to random Pokémon with worse stats",
+                "Into random Pokémon with worse stats",
+                "To random Pokémon with worse stats",
+                "Random Pokémon with worse stats",
+                "Random Pokémon, worse stats",
+                "Random Pokémon worse stats",
+                "Random, worse stats",
+                "Random worse stats",
+                "Worse stats",
+            },
+        },
+        .{
+            .names = &[_][]const u8{
+                "Form Stone",
+                "Form Rock",
+                "Form Rck",
+                "T Stone",
+                "T Rock",
+                "T Rck",
+            },
+            .descriptions = &[_][]const u8{
+                "Evolves a Pokémon into random Pokémon with a common type.",
+                "Evolves a Pokémon into random Pokémon with a common type",
+                "Evolve a Pokémon into random Pokémon with a common type",
+                "Evolves a Pokémon to random Pokémon with a common type",
+                "Evolve a Pokémon to random Pokémon with a common type",
+                "Evolves to random Pokémon with a common type",
+                "Evolve to random Pokémon with a common type",
+                "Evolve to random Pokémon with same type",
+                "Into random Pokémon with a common type",
+                "Into random Pokémon with same type",
+                "To random Pokémon with same type",
+                "Random Pokémon, a common type",
+                "Random Pokémon a common type",
+                "Random Pokémon, same type",
+                "Random Pokémon same type",
+                "Random, a common type",
+                "Random a common type",
+                "Random, same type",
+                "Random same type",
+                "A common type",
+                "Same type",
+            },
+        },
+        .{
+            .names = &[_][]const u8{
+                "Skill Stone",
+                "Skill Rock",
+                "Skill Rck",
+                "S Stone",
+                "S Rock",
+                "S Rck",
+            },
+            .descriptions = &[_][]const u8{
+                "Evolves a Pokémon into random Pokémon with a common ability.",
+                "Evolves a Pokémon into random Pokémon with a common ability",
+                "Evolve a Pokémon into random Pokémon with a common ability",
+                "Evolves a Pokémon to random Pokémon with a common ability",
+                "Evolve a Pokémon to random Pokémon with a common ability",
+                "Evolves to random Pokémon with a common ability",
+                "Evolve to random Pokémon with a common ability",
+                "Evolve to random Pokémon with same ability",
+                "Into random Pokémon with a common ability",
+                "Into random Pokémon with same ability",
+                "To random Pokémon with same ability",
+                "Random Pokémon, a common ability",
+                "Random Pokémon a common ability",
+                "Random Pokémon, same ability",
+                "Random Pokémon same ability",
+                "Random, a common ability",
+                "Random a common ability",
+                "Random, same ability",
+                "Random same ability",
+                "A common ability",
+                "Same ability",
+            },
+        },
+        .{
+            .names = &[_][]const u8{
+                "Breed Stone",
+                "Breed Rock",
+                "Egg Stone",
+                "Egg Rock",
+                "Egg Rck",
+                "E Stone",
+                "E Rock",
+                "E Rck",
+            },
+            .descriptions = &[_][]const u8{
+                "Evolves a Pokémon into random Pokémon in the same egg group.",
+                "Evolves a Pokémon into random Pokémon in the same egg group",
+                "Evolve a Pokémon into random Pokémon in the same egg group",
+                "Evolves a Pokémon to random Pokémon in the same egg group",
+                "Evolve a Pokémon to random Pokémon in the same egg group",
+                "Evolves to random Pokémon in the same egg group",
+                "Evolve to random Pokémon in the same egg group",
+                "Evolve to random Pokémon with same egg group",
+                "Into random Pokémon in the same egg group",
+                "Into random Pokémon with same egg group",
+                "To random Pokémon with same egg group",
+                "Random Pokémon, in same egg group",
+                "Random Pokémon in same egg group",
+                "Random Pokémon, same egg group",
+                "Random Pokémon same egg group",
+                "Random, in same egg group",
+                "Random in same egg group",
+                "Random, same egg group",
+                "Random same egg group",
+                "In same egg group",
+                "Same egg group",
+            },
+        },
+        .{
+            .names = &[_][]const u8{
+                "Buddy Stone",
+                "Buddy Rock",
+                "Buddy Rck",
+                "F Stone",
+                "F Rock",
+                "F Rck",
+            },
+            .descriptions = &[_][]const u8{
+                "Evolves a Pokémon into random Pokémon with the same base friendship.",
+                "Evolves a Pokémon into random Pokémon with the same base friendship",
+                "Evolves a Pokémon into random Pokémon with the same base friendship",
+                "Evolves a Pokémon into random Pokémon with the same friendship",
+                "Evolves to random Pokémon with the same base friendship",
+                "Evolve to random Pokémon with the same base friendship",
+                "Evolve to random Pokémon with same base friendship",
+                "Evolves to random Pokémon with the same friendship",
+                "Evolve to random Pokémon with the same friendship",
+                "Evolve to random Pokémon with same friendship",
+                "Into random Pokémon with the same friendship",
+                "Into random Pokémon with same friendship",
+                "To random Pokémon with same friendship",
+                "Random Pokémon, with same friendship",
+                "Random Pokémon with same friendship",
+                "Random Pokémon, same friendship",
+                "Random Pokémon same friendship",
+                "Random, with same friendship",
+                "Random with same friendship",
+                "Random, same friendship",
+                "Random same friendship",
+                "In same friendship",
+                "Same friendship",
+            },
+        },
+    };
+    for (stone_strings) |strings, stone| {
+        if (data.max_evolutions <= stone or stones.count() <= stone)
+            break;
+
+        const item_id = stones.at(stone);
+        const item = data.items.get(item_id).?;
+
+        // We have no idea as to how long the name/desc can be in the game we
+        // are working on. Our best guess will therefor be to use the current
+        // items name/desc as the limits and pick something that fits.
+        item.* = Item{
+            .name = pickString(item.name.len, strings.names),
+            .description = pickString(item.description.len, strings.descriptions),
+        };
+    }
+
+    const num_pokemons = data.pokemons.count();
+    for (data.pokemons.values()) |*pokemon, i| {
+        const pokemon_id = data.pokemons.at(i).key;
+
+        for (stone_strings) |strings, stone| {
+            if (data.max_evolutions <= stone or stones.count() <= stone)
+                break;
+
+            const item_id = stones.at(stone);
+            const pick = switch (stone) {
+                chance_stone => while (num_pokemons > 1) {
+                    const pick = random.intRangeLessThan(usize, 0, num_pokemons);
+                    if (pick != pokemon_id)
+                        break pick;
+                } else pokemon_id,
+
+                superior_stone, poor_stone => blk: {
+                    const total_stats = sum(&pokemon.stats);
+
+                    // Intmaps/sets have sorted keys. We can therefor pick an index
+                    // above or below the current one, to get a set of Pokémons whose
+                    // stats are better or worse than the current one.
+                    const stat_index = pokemons_by_stats.set.index(total_stats).?;
+                    const picked_index = switch (stone) {
+                        superior_stone => random.intRangeLessThan(
+                            usize,
+                            stat_index + @boolToInt(stat_index + 1 < pokemons_by_stats.count()),
+                            pokemons_by_stats.count(),
+                        ),
+                        poor_stone => random.intRangeLessThan(
+                            usize,
+                            0,
+                            (stat_index - @boolToInt(stat_index != 0)) + 1,
+                        ),
+                        else => unreachable,
+                    };
+
+                    const set = pokemons_by_stats.at(picked_index).value;
+                    while (set.count() != 1) {
+                        const pick = set.at(random.intRangeLessThan(usize, 0, set.count()));
+                        if (pick != pokemon_id)
+                            break :blk pick;
+                    }
+
+                    break :blk set.at(0);
+                },
+
+                form_stone, skill_stone, breed_stone => blk: {
+                    const map = switch (stone) {
+                        form_stone => data.pokemons_by_type,
+                        skill_stone => data.pokemons_by_ability,
+                        breed_stone => data.pokemons_by_egg_group,
+                        else => unreachable,
+                    };
+                    const set = switch (stone) {
+                        form_stone => pokemon.types,
+                        skill_stone => pokemon.abilities,
+                        breed_stone => pokemon.egg_groups,
+                        else => unreachable,
+                    };
+
+                    const map_count = map.count();
+                    if (map_count == 0)
+                        break :blk pokemon_id;
+
+                    const picked_id = set.at(random.intRangeLessThan(usize, 0, set.count()));
+                    const pokemon_set = map.get(picked_id).?;
+                    const pokemons = pokemon_set.count();
+                    while (pokemons != 1) {
+                        const pick = pokemon_set.at(random.intRangeLessThan(usize, 0, pokemons));
+                        if (pick != pokemon_id)
+                            break :blk pick;
+                    }
+                    break :blk pokemon_id;
+                },
+
+                buddy_stone => blk: {
+                    const map_count = data.pokemons_by_base_friendship.count();
+                    if (map_count == 0)
+                        break :blk pokemon_id;
+
+                    const pokemon_set = data.pokemons_by_base_friendship.get(pokemon.base_friendship).?;
+                    const pokemons = pokemon_set.count();
+                    while (pokemons != 1) {
+                        const pick = pokemon_set.at(random.intRangeLessThan(usize, 0, pokemons));
+                        if (pick != pokemon_id)
+                            break :blk pick;
+                    }
+                    break :blk pokemon_id;
+                },
+                else => unreachable,
+            };
+
+            _ = try pokemon.evos.put(allocator, stone, Evolution{
+                .method = use_item_method,
+                .item = item_id,
+                .target = pick,
+            });
+        }
+    }
+
+    const number_of_stones = math.min(math.min(stones.count(), stone_strings.len), data.max_evolutions);
+    for (data.pokeball_items.values()) |*item_id| {
+        const item = data.items.get(item_id.*) orelse continue;
+        if (item.price == 0 or item.price > 600)
+            continue;
+        const pick = random.intRangeLessThan(usize, 0, number_of_stones);
+        item_id.* = stones.at(pick);
+    }
+}
+
+fn sum(buf: []const u8) usize {
+    var res: usize = 0;
+    for (buf) |item|
+        res += item;
+
+    return res;
+}
+
+fn pickString(len: usize, strings: []const []const u8) []const u8 {
+    var pick = strings[0];
+    for (strings) |str| {
+        pick = str;
+        if (str.len <= len)
+            break;
+    }
+
+    return pick[0..math.min(len, pick.len)];
+}
+
+const Set = util.container.IntSet.Unmanaged(usize);
+const PokemonBy = util.container.IntMap.Unmanaged(usize, Set);
+const Items = util.container.IntMap.Unmanaged(usize, Item);
+const Pokemons = util.container.IntMap.Unmanaged(usize, Pokemon);
+const Evolutions = util.container.IntMap.Unmanaged(usize, Evolution);
+const PokeballItems = util.container.IntMap.Unmanaged(usize, usize);
+
+const Data = struct {
+    strings: std.StringHashMap(usize),
+    max_evolutions: usize = 0,
+    stones: Set = Set{},
+    items: Items = Items{},
+    pokeball_items: PokeballItems = PokeballItems{},
+    pokemons: Pokemons = Pokemons{},
+    pokemons_by_ability: PokemonBy = PokemonBy{},
+    pokemons_by_type: PokemonBy = PokemonBy{},
+    pokemons_by_egg_group: PokemonBy = PokemonBy{},
+    pokemons_by_base_friendship: PokemonBy = PokemonBy{},
+
+    fn string(d: *Data, str: []const u8) !usize {
+        const res = try d.strings.getOrPut(str);
+        if (!res.found_existing) {
+            res.kv.key = try mem.dupe(d.strings.allocator, u8, str);
+            res.kv.value = d.strings.count() - 1;
+        }
+        return res.kv.value;
+    }
+};
+
+const Pokemon = struct {
+    evos: Evolutions = Evolutions{},
+    stats: [6]u8 = [_]u8{0} ** 6,
+    base_friendship: usize = 0,
+    abilities: Set = Set{},
+    types: Set = Set{},
+    egg_groups: Set = Set{},
+};
+
+const Item = struct {
+    name: []const u8 = "",
+    description: []const u8 = "",
+    price: usize = 0,
+};
+
+const Evolution = struct {
+    method: usize,
+    item: usize = 0,
+    target: usize = 0,
+};
+
+test "tm35-random stones" {
+    // TODO: Tests
+}

--- a/src/randomizers/tm35-random-stones.zig
+++ b/src/randomizers/tm35-random-stones.zig
@@ -47,7 +47,7 @@ fn usage(stream: var) !void {
         "\n" ++
         "This command will try to get as many of these stones into the game as possible, " ++
         "but beware, that all stones might not exist. Also beware, that the stones might " ++
-        "have different (but simular) names in cases wherethe game does not support long " ++
+        "have different (but simular) names in cases where the game does not support long " ++
         "item names.\n" ++
         "\n" ++
         "Options:\n");

--- a/test-real-roms.sh
+++ b/test-real-roms.sh
@@ -28,11 +28,10 @@ for release in $(printf "false\ntrue\n"); do
         zig-cache/bin/tm35-load "$rom_dest" > "$found"
         diff -q "$expect" "$found"
 
-        # Change all numbers in rom to 1
-        sed -i "s/=[0-9]+$/=1/" "$expect"
-
-        # Change all names in rom to 'a'
-        sed -i "s/\.name=.*$/.name=a/" "$expect"
+        sed -i -E \
+            -e "s/([^y])=([0-9]).*$/\1=\2/" \
+            -e "s/\.name=.*$/.name=a/" \
+            "$expect"
         zig-cache/bin/tm35-apply "$rom" -aro "$rom_dest" < "$expect"
         zig-cache/bin/tm35-load "$rom_dest" > "$found"
         diff -q "$expect" "$found"


### PR DESCRIPTION
Implements the following help:

```
Changes all Pokémons to evolve using new evolution stones. These stones evolve
a Pokémon to a random new Pokémon that upholds the requirements of the stone.
Here is a list of all stones:
* Chance Stone: Evolves a Pokémon into random Pokémon.
* Superior Stone: Evolves a Pokémon into random Pokémon with better overall stats.
* Poor Stone: Evolves a Pokémon into random Pokémon with worse overall stats.
* Form Stone: Evolves a Pokémon into random Pokémon with a common type.
* Skill Stone: Evolves a Pokémon into random Pokémon with a common ability.
* Breed Stone: Evolves a Pokémon into random Pokémon in the same egg group.
* Buddy Stone: Evolves a Pokémon into random Pokémon with the same base friendship.

This command will try to get as many of these stones into the game as possible, but
beware, that all stones might not exist. Also beware, that the stones might have different
(but simular) names in cases where the game does not support long item names.
```