### PR TITLE
Better nds resize

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -201,11 +201,10 @@ pub fn build(b: *Builder) void {
         exe.linkSystemLibrary("c");
         exe.linkSystemLibrary("m");
 
-        exe.install();
         exe.setTarget(target);
         exe.setBuildMode(mode);
         exe.single_threaded = true;
-        build_gui_step.dependOn(&exe.step);
+        build_gui_step.dependOn(&b.addInstallArtifact(exe).step);
     }
 }
 
@@ -223,7 +222,7 @@ fn buildAndInstallCmdlineProgram(
         exe.addPackage(pkg);
 
     if (install)
-        exe.install();
+        parent_step.dependOn(&b.addInstallArtifact(exe).step);
     exe.setTarget(target);
     exe.setBuildMode(mode);
     exe.single_threaded = true;

--- a/src/core/tm35-apply.zig
+++ b/src/core/tm35-apply.zig
@@ -147,7 +147,6 @@ pub fn main2(
 
     var line_num: usize = 1;
     while (util.readLine(stdio.in.context) catch |err| return exit.stdinErr(stdio.err, err)) |line| : (line_num += 1) {
-        var timer = std.time.Timer.start() catch unreachable;
         const trimmed = mem.trimRight(u8, line, "\r\n");
         const new_bytes = switch (game) {
             .gen3 => |*gen3_game| blk: {

--- a/test-real-roms.sh
+++ b/test-real-roms.sh
@@ -21,7 +21,7 @@ expect=$(mktemp)
 found=$(mktemp)
 
 for release in $(printf "false\ntrue\n"); do
-    zig build "-Drelease=$release"
+    zig build build-core "-Drelease=$release"
     for rom in $@; do
         echo "$rom" >&2
         zig-cache/bin/tm35-load "$rom" > "$expect"


### PR DESCRIPTION
This is a PR to improve the speed of `nds.Rom.resizeSection` by avoiding large memory copies when possible. Instead, this function will move sections to the end of the file when they can not be resized inline.