### PR TITLE
Make metronome compile with zigs new bootstrapped compiler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,6 @@ jobs:
       - uses: goto-bus-stop/setup-zig@v1
         with:
           version: master
-      - if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev -y
       - run: zig build test -D${{ matrix.release }}
 
   build:

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,9 +10,6 @@
 [submodule "lib/known-folders"]
 	path = lib/known-folders
 	url = ../../ziglibs/known-folders.git
-[submodule "lib/ziter"]
-	path = lib/ziter
-	url = ../../Hejsil/ziter.git
 [submodule "lib/ston"]
 	path = lib/ston
 	url = ../../Hejsil/ston.git

--- a/src/common/escape.zig
+++ b/src/common/escape.zig
@@ -162,7 +162,7 @@ pub const Replacement = struct {
     find: []const u8,
     replace: []const u8,
 
-    fn lessThan(_: void, a: Replacement, b: Replacement) bool {
+    fn lessThan(_: u8, a: Replacement, b: Replacement) bool {
         return mem.lessThan(u8, a.find, b.find);
     }
 };
@@ -217,7 +217,7 @@ test "transion" {
 pub fn ReplacingWriter(comptime replacements: []const Replacement, comptime ChildWriter: type) type {
     @setEvalBranchQuota(1000000);
     comptime var replacements_sorted = replacements[0..replacements.len].*;
-    std.sort.sort(Replacement, &replacements_sorted, {}, Replacement.lessThan);
+    std.sort.sort(Replacement, &replacements_sorted, @as(u8, 0), Replacement.lessThan);
 
     return struct {
         child_writer: ChildWriter,

--- a/src/common/testing.zig
+++ b/src/common/testing.zig
@@ -80,7 +80,7 @@ pub const Pattern = struct {
     min: usize,
     max: usize,
     ctx: Context,
-    find: fn (Context, []const u8, usize) ?usize,
+    find: std.meta.FnPtr(fn (Context, []const u8, usize) ?usize),
 
     pub fn string(min: usize, max: usize, str: []const u8) Pattern {
         return .{

--- a/src/core/common.zig
+++ b/src/core/common.zig
@@ -184,7 +184,7 @@ pub const EggGroup = enum(u8) {
     _,
 };
 
-pub const ColorKind = enum(u7) {
+pub const Color = enum(u8) {
     red = 0x00,
     blue = 0x01,
     yellow = 0x02,
@@ -196,11 +196,19 @@ pub const ColorKind = enum(u7) {
     white = 0x08,
     pink = 0x09,
     green2 = 0x0A,
-};
 
-pub const Color = packed struct {
-    color: ColorKind,
-    flip: bool,
+    flipped_red = 0x80,
+    flipped_blue = 0x81,
+    flipped_yellow = 0x82,
+    flipped_green = 0x83,
+    flipped_black = 0x84,
+    flipped_brown = 0x85,
+    flipped_purple = 0x86,
+    flipped_gray = 0x87,
+    flipped_white = 0x88,
+    flipped_pink = 0x89,
+    flipped_green2 = 0x8A,
+    _,
 };
 
 // Common between gen3-4

--- a/src/core/gen3/offsets.zig
+++ b/src/core/gen3/offsets.zig
@@ -31,7 +31,7 @@ pub fn Offset(comptime _T: type) type {
             return offset.offset + @sizeOf(T);
         }
 
-        pub fn ptr(offset: @This(), data: []u8) *T {
+        pub fn ptr(offset: @This(), data: []u8) *align(1) T {
             return &mem.bytesAsSlice(T, data[offset.offset..][0..@sizeOf(T)])[0];
         }
     };
@@ -44,7 +44,7 @@ pub fn Section(comptime _Item: type) type {
         start: usize,
         len: usize,
 
-        pub fn init(data_slice: []const u8, items: []const Item) @This() {
+        pub fn init(data_slice: []const u8, items: []align(1) const Item) @This() {
             const data_ptr = @ptrToInt(data_slice.ptr);
             const item_ptr = @ptrToInt(items.ptr);
             debug.assert(data_ptr <= item_ptr);
@@ -60,7 +60,7 @@ pub fn Section(comptime _Item: type) type {
             return sec.start + @sizeOf(Item) * sec.len;
         }
 
-        pub fn slice(sec: @This(), data: []u8) []Item {
+        pub fn slice(sec: @This(), data: []u8) []align(1) Item {
             return mem.bytesAsSlice(Item, data[sec.start..sec.end()]);
         }
     };

--- a/src/core/gen3/script.zig
+++ b/src/core/gen3/script.zig
@@ -35,46 +35,46 @@ pub const STD_REGISTER_MATCH_CALL = 8;
 pub const Command = extern union {
     kind: Kind,
     // Does nothing.
-    nop: arg0,
+    nop: Arg0,
 
     // Does nothing.
-    nop1: arg0,
+    nop1: Arg0,
 
     // Terminates script execution.
-    end: arg0,
+    end: Arg0,
 
     // Jumps back to after the last-executed call statement, and continues script execution from there.
-    @"return": arg0,
+    @"return": Arg0,
 
     // Jumps to destination and continues script execution from there. The location of the calling script is remembered and can be returned to later.
-    call: call,
+    call: Jump,
 
     // Jumps to destination and continues script execution from there.
-    goto: goto,
+    goto: Jump,
 
     // If the result of the last comparison matches condition (see Comparison operators), jumps to destination and continues script execution from there.
-    goto_if: goto_if,
+    goto_if: CondJump,
 
     // If the result of the last comparison matches condition (see Comparison operators), calls destination.
-    call_if: call_if,
+    call_if: CondJump,
 
     // Jumps to the standard function at index function.
-    gotostd: gotostd,
+    gotostd: Func(u8),
 
     // Calls the standard function at index function.
-    callstd: callstd,
+    callstd: Func(u8),
 
     // If the result of the last comparison matches condition (see Comparison operators), jumps to the standard function at index function.
-    gotostd_if: gotostd_if,
+    gotostd_if: CondFunc,
 
     // If the result of the last comparison matches condition (see Comparison operators), calls the standard function at index function.
-    callstd_if: callstd_if,
+    callstd_if: CondFunc,
 
     // Executes a script stored in a default RAM location.
-    gotoram: arg0,
+    gotoram: Arg0,
 
     // Terminates script execution and "resets the script RAM".
-    killscript: arg0,
+    killscript: Arg0,
 
     // Sets some status related to Mystery Event.
     setmysteryeventstatus: setmysteryeventstatus,
@@ -89,49 +89,49 @@ pub const Command = extern union {
     writebytetoaddr: writebytetoaddr,
 
     // Copies the byte value at source into the specified script bank.
-    loadbytefromaddr: loadbytefromaddr,
+    loadbytefromaddr: DestSrc(u8, lu32),
 
     // Not sure. Judging from XSE's description I think it takes the least-significant byte in bank source and writes it to destination.
     setptrbyte: setptrbyte,
 
     // Copies the contents of bank source into bank destination.
-    copylocal: copylocal,
+    copylocal: DestSrc(u8, u8),
 
     // Copies the byte at source to destination, replacing whatever byte was previously there.
-    copybyte: copybyte,
+    copybyte: DestSrc(lu32, lu32),
 
     // Changes the value of destination to value.
-    setvar: setvar,
+    setvar: DestVal,
 
-    //  // Changes the value of destination by adding value to it. Overflow is not prevented (0xFFFF + 1 = 0x0000).
-    addvar: addvar,
+    // Changes the value of destination by adding value to it. Overflow is not prevented (0xFFFF + 1 = 0x0000).
+    addvar: DestVal,
 
-    //  // Changes the value of destination by subtracting value to it. Overflow is not prevented (0x0000 - 1 = 0xFFFF).
-    subvar: subvar,
+    // Changes the value of destination by subtracting value to it. Overflow is not prevented (0x0000 - 1 = 0xFFFF).
+    subvar: DestVal,
 
     // Copies the value of source into destination.
-    copyvar: copyvar,
+    copyvar: DestSrc(lu16, lu16),
 
     // If source is not a variable, then this function acts like setvar. Otherwise, it acts like copyvar.
-    setorcopyvar: setorcopyvar,
+    setorcopyvar: DestSrc(lu16, lu16),
 
     // Compares the values of script banks a and b, after forcing the values to bytes.
-    compare_local_to_local: compare_local_to_local,
+    compare_local_to_local: AB(u8, u8),
 
     // Compares the least-significant byte of the value of script bank a to a fixed byte value (b).
-    compare_local_to_value: compare_local_to_value,
+    compare_local_to_value: AB(u8, u8),
 
     // Compares the least-significant byte of the value of script bank a to the byte located at offset b.
-    compare_local_to_addr: compare_local_to_addr,
+    compare_local_to_addr: AB(u8, lu32),
 
     // Compares the byte located at offset a to the least-significant byte of the value of script bank b.
-    compare_addr_to_local: compare_addr_to_local,
+    compare_addr_to_local: AB(lu32, u8),
 
     // Compares the byte located at offset a to a fixed byte value (b).
-    compare_addr_to_value: compare_addr_to_value,
+    compare_addr_to_value: AB(lu32, u8),
 
     // Compares the byte located at offset a to the byte located at offset b.
-    compare_addr_to_addr: compare_addr_to_addr,
+    compare_addr_to_addr: AB(lu32, lu32),
 
     // Compares the value of `var` to a fixed word value (b).
     compare_var_to_value: compare_var_to_value,
@@ -140,103 +140,103 @@ pub const Command = extern union {
     compare_var_to_var: compare_var_to_var,
 
     // Calls the native C function stored at `func`.
-    callnative: callnative,
+    callnative: Func(lu32),
 
     // Replaces the script with the function stored at `func`. Execution returns to the bytecode script when func returns TRUE.
-    gotonative: gotonative,
+    gotonative: Func(lu32),
 
     // Calls a special function; that is, a function designed for use by scripts and listed in a table of pointers.
-    special: special,
+    special: Func(lu16),
 
     // Calls a special function. That function's output (if any) will be written to the variable you specify.
     specialvar: specialvar,
 
     // Blocks script execution until a command or ASM code manually unblocks it. Generally used with specific commands and specials. If this command runs, and a subsequent command or piece of ASM does not unblock state, the script will remain blocked indefinitely (essentially a hang).
-    waitstate: arg0,
+    waitstate: Arg0,
 
     // Blocks script execution for time (frames? milliseconds?).
     delay: delay,
 
-    // Sets a to 1.
-    setflag: setflag,
+    // Sets arg to 1.
+    setflag: Arg1,
 
-    // Sets a to 0.
-    clearflag: clearflag,
+    // Sets arg to 0.
+    clearflag: Arg1,
 
-    // Compares a to 1.
-    checkflag: checkflag,
+    // Compares arg to 1.
+    checkflag: Arg1,
 
     // Initializes the RTC`s local time offset to the given hour and minute. In FireRed, this command is a nop.
     initclock: initclock,
 
     // Runs time based events. In FireRed, this command is a nop.
-    dodailyevents: arg0,
+    dodailyevents: Arg0,
 
     // Sets the values of variables 0x8000, 0x8001, and 0x8002 to the current hour, minute, and second. In FRLG, this command sets those variables to zero.
-    gettime: arg0,
+    gettime: Arg0,
 
     // Plays the specified (sound_number) sound. Only one sound may play at a time, with newer ones interrupting older ones.
-    playse: playse,
+    playse: Song,
 
     // Blocks script execution until the currently-playing sound (triggered by playse) finishes playing.
-    waitse: arg0,
+    waitse: Arg0,
 
     // Plays the specified (fanfare_number) fanfare.
-    playfanfare: playfanfare,
+    playfanfare: Song,
 
     // Blocks script execution until all currently-playing fanfares finish.
-    waitfanfare: arg0,
+    waitfanfare: Arg0,
 
     // Plays the specified (song_number) song. The byte is apparently supposed to be 0x00.
     playbgm: playbgm,
 
     // Saves the specified (song_number) song to be played later.
-    savebgm: savebgm,
+    savebgm: Song,
 
     // Crossfades the currently-playing song into the map's default song.
-    fadedefaultbgm: arg0,
+    fadedefaultbgm: Arg0,
 
     // Crossfades the currently-playng song into the specified (song_number) song.
-    fadenewbgm: fadenewbgm,
+    fadenewbgm: Song,
 
     // Fades out the currently-playing song.
-    fadeoutbgm: fadeoutbgm,
+    fadeoutbgm: Speed,
 
     // Fades the previously-playing song back in.
-    fadeinbgm: fadeinbgm,
+    fadeinbgm: Speed,
 
     // Sends the player to Warp warp on Map bank.map. If the specified warp is 0xFF, then the player will instead be sent to (X, Y) on the map.
-    warp: warp,
+    warp: Warp,
 
     // Clone of warp that does not play a sound effect.
-    warpsilent: warpsilent,
+    warpsilent: Warp,
 
     // Clone of warp that plays a door opening animation before stepping upwards into it.
-    warpdoor: warpdoor,
+    warpdoor: Warp,
 
     // Warps the player to another map using a hole animation.
     warphole: warphole,
 
     // Clone of warp that uses a teleport effect. It is apparently only used in R/S/E.
-    warpteleport: warpteleport,
+    warpteleport: Warp,
 
     // Sets the warp destination to be used later.
-    setwarp: setwarp,
+    setwarp: Warp,
 
     // Sets the warp destination that a warp to Warp 127 on Map 127.127 will connect to. Useful when a map has warps that need to go to script-controlled locations (i.e. elevators).
-    setdynamicwarp: setdynamicwarp,
+    setdynamicwarp: Warp,
 
     // Sets the destination that diving or emerging from a dive will take the player to.
-    setdivewarp: setdivewarp,
+    setdivewarp: Warp,
 
     // Sets the destination that falling into a hole will take the player to.
-    setholewarp: setholewarp,
+    setholewarp: Warp,
 
     // Retrieves the player's zero-indexed X- and Y-coordinates in the map, and stores them in the specified variables.
     getplayerxy: getplayerxy,
 
     // Retrieves the number of Pokemon in the player's party, and stores that number in variable 0x800D (LASTRESULT).
-    getpartysize: arg0,
+    getpartysize: Arg0,
 
     // Attempts to add quantity of item index to the player's Bag. If the player has enough room, the item will be added and variable 0x800D (LASTRESULT) will be set to 0x0001; otherwise, LASTRESULT is set to 0x0000.
     additem: additem,
@@ -299,56 +299,56 @@ pub const Command = extern union {
     hideobjectat: hideobjectat,
 
     // If the script was called by an Object, then that Object will turn to face toward the metatile that the player is standing on.
-    faceplayer: arg0,
+    faceplayer: Arg0,
     turnobject: turnobject,
 
     // If the Trainer flag for Trainer index is not set, this command does absolutely nothing.
     trainerbattle: trainerbattle,
 
     // Starts a trainer battle using the battle information stored in RAM (usually by trainerbattle, which actually calls this command behind-the-scenes), and blocks script execution until the battle finishes.
-    trainerbattlebegin: arg0,
+    trainerbattlebegin: Arg0,
 
     // Goes to address after the trainerbattle command (called by the battle functions, see battle_setup.c)
-    gotopostbattlescript: arg0,
+    gotopostbattlescript: Arg0,
 
     // Goes to address specified in the trainerbattle command (called by the battle functions, see battle_setup.c)
-    gotobeatenscript: arg0,
+    gotobeatenscript: Arg0,
 
     // Compares Flag (trainer + 0x500) to 1. (If the flag is set, then the trainer has been defeated by the player.)
-    checktrainerflag: checktrainerflag,
+    checktrainerflag: Trainer,
 
     // Sets Flag (trainer + 0x500).
-    settrainerflag: settrainerflag,
+    settrainerflag: Trainer,
 
     // Clears Flag (trainer + 0x500).
-    cleartrainerflag: cleartrainerflag,
+    cleartrainerflag: Trainer,
     setobjectxyperm: setobjectxyperm,
     moveobjectoffscreen: moveobjectoffscreen,
     setobjectmovementtype: setobjectmovementtype,
 
     // If a standard message box (or its text) is being drawn on-screen, this command blocks script execution until the box and its text have been fully drawn.
-    waitmessage: arg0,
+    waitmessage: Arg0,
 
     // Starts displaying a standard message box containing the specified text. If text is a pointer, then the string at that offset will be loaded and used. If text is script bank 0, then the value of script bank 0 will be treated as a pointer to the text. (You can use loadpointer to place a string pointer in a script bank.)
     message: message,
 
     // Closes the current message box.
-    closemessage: arg0,
+    closemessage: Arg0,
 
     // Ceases movement for all Objects on-screen.
-    lockall: arg0,
+    lockall: Arg0,
 
     // If the script was called by an Object, then that Object's movement will cease.
-    lock: arg0,
+    lock: Arg0,
 
     // Resumes normal movement for all Objects on-screen, and closes any standard message boxes that are still open.
-    releaseall: arg0,
+    releaseall: Arg0,
 
     // If the script was called by an Object, then that Object's movement will resume. This command also closes any standard message boxes that are still open.
-    release: arg0,
+    release: Arg0,
 
     // Blocks script execution until the player presses any key.
-    waitbuttonpress: arg0,
+    waitbuttonpress: Arg0,
 
     // Displays a YES/NO multichoice box at the specified coordinates, and blocks script execution until the user makes a selection. Their selection is stored in variable 0x800D (LASTRESULT); 0x0000 for "NO" or if the user pressed B, and 0x0001 for "YES".
     yesnobox: yesnobox,
@@ -363,7 +363,7 @@ pub const Command = extern union {
     multichoicegrid: multichoicegrid,
 
     // Nopped in Emerald.
-    drawbox: arg0,
+    drawbox: Arg0,
 
     // Nopped in Emerald, but still consumes parameters.
     erasebox: erasebox,
@@ -375,7 +375,7 @@ pub const Command = extern union {
     drawmonpic: drawmonpic,
 
     // Hides all boxes displayed with drawmonpic.
-    erasemonpic: arg0,
+    erasemonpic: Arg0,
 
     // Draws an image of the winner of the contest. In FireRed, this command is a nop. (The argument is discarded.)
     drawcontestwinner: drawcontestwinner,
@@ -434,16 +434,16 @@ pub const Command = extern union {
     setberrytree: setberrytree,
 
     // This allows you to choose a Pokemon to use in a contest. In FireRed, this command sets the byte at 0x03000EA8 to 0x01.
-    choosecontestmon: arg0,
+    choosecontestmon: Arg0,
 
     // Starts a contest. In FireRed, this command is a nop.
-    startcontest: arg0,
+    startcontest: Arg0,
 
     // Shows the results of a contest. In FireRed, this command is a nop.
-    showcontestresults: arg0,
+    showcontestresults: Arg0,
 
     // Starts a contest over a link connection. In FireRed, this command is a nop.
-    contestlinktransfer: arg0,
+    contestlinktransfer: Arg0,
 
     // Stores a random integer between 0 and limit in variable 0x800D (LASTRESULT).
     random: random,
@@ -461,7 +461,7 @@ pub const Command = extern union {
     showmoneybox: showmoneybox,
 
     // Hides the secondary box spawned by showmoney.
-    hidemoneybox: arg0,
+    hidemoneybox: Arg0,
 
     // Updates the secondary box spawned by showmoney. Consumes but does not use arguments.
     updatemoneybox: updatemoneybox,
@@ -476,7 +476,7 @@ pub const Command = extern union {
     fadescreenspeed: fadescreenspeed,
     setflashradius: setflashradius,
     animateflash: animateflash,
-    messageautoscroll: messageautoscroll,
+    messageautoscroll: Pointer,
 
     // Executes the specified field move animation.
     dofieldeffect: dofieldeffect,
@@ -491,7 +491,7 @@ pub const Command = extern union {
     setrespawn: setrespawn,
 
     // Checks the player's gender. If male, then 0x0000 is stored in variable 0x800D (LASTRESULT). If female, then 0x0001 is stored in LASTRESULT.
-    checkplayergender: arg0,
+    checkplayergender: Arg0,
 
     // Plays the specified (species) Pokemon's cry. You can use waitcry to block script execution until the sound finishes.
     playmoncry: playmoncry,
@@ -500,13 +500,13 @@ pub const Command = extern union {
     setmetatile: setmetatile,
 
     // Queues a weather change to the default weather for the map.
-    resetweather: arg0,
+    resetweather: Arg0,
 
     // Queues a weather change to type weather.
     setweather: setweather,
 
     // Executes the weather change queued with resetweather or setweather. The current weather will smoothly fade into the queued weather.
-    doweather: arg0,
+    doweather: Arg0,
 
     // This command manages cases in which maps have tiles that change state when stepped on (specifically, cracked/breakable floors).
     setstepcallback: setstepcallback,
@@ -523,7 +523,7 @@ pub const Command = extern union {
     closedoor: closedoor,
 
     // Waits for the door animation started with opendoor or closedoor to finish.
-    waitdooranim: arg0,
+    waitdooranim: Arg0,
 
     // Sets the door tile at (x, y) to be open without an animation.
     setdooropen: setdooropen,
@@ -535,7 +535,7 @@ pub const Command = extern union {
     addelevmenuitem: addelevmenuitem,
 
     // In FireRed and Emerald, this command is a nop.
-    showelevmenu: arg0,
+    showelevmenu: Arg0,
     checkcoins: checkcoins,
     givecoins: givecoins,
     takecoins: takecoins,
@@ -544,33 +544,33 @@ pub const Command = extern union {
     setwildbattle: setwildbattle,
 
     // Starts a wild battle against the Pokemon generated by setwildbattle. Blocks script execution until the battle finishes.
-    dowildbattle: arg0,
-    setvaddress: setvaddress,
-    vgoto: vgoto,
-    vcall: vcall,
-    vgoto_if: vgoto_if,
-    vcall_if: vcall_if,
-    vmessage: vmessage,
-    vloadptr: vloadptr,
-    vbufferstring: vbufferstring,
+    dowildbattle: Arg0,
+    setvaddress: Pointer,
+    vgoto: Pointer,
+    vcall: Pointer,
+    vgoto_if: CondJump,
+    vcall_if: CondJump,
+    vmessage: Pointer,
+    vloadptr: Pointer,
+    vbufferstring: CondJump,
 
     // Spawns a secondary box showing how many Coins the player has.
-    showcoinsbox: showcoinsbox,
+    showcoinsbox: Coord,
 
     // Hides the secondary box spawned by showcoins. It consumes its arguments but doesn't use them.
-    hidecoinsbox: hidecoinsbox,
+    hidecoinsbox: Coord,
 
     // Updates the secondary box spawned by showcoins. It consumes its arguments but doesn't use them.
-    updatecoinsbox: updatecoinsbox,
+    updatecoinsbox: Coord,
 
     // Increases the value of the specified game stat by 1. The stat's value will not be allowed to exceed 0x00FFFFFF.
     incrementgamestat: incrementgamestat,
 
     // Sets the destination that using an Escape Rope or Dig will take the player to.
-    setescapewarp: setescapewarp,
+    setescapewarp: Warp,
 
     // Blocks script execution until cry finishes.
-    waitmoncry: arg0,
+    waitmoncry: Arg0,
 
     // Writes the name of the specified (box) PC box to the specified buffer.
     bufferboxname: bufferboxname,
@@ -579,52 +579,52 @@ pub const Command = extern union {
     textcolor: textcolor,
 
     // The exact purpose of this command is unknown, but it is related to the blue help-text box that appears on the bottom of the screen when the Main Menu is opened.
-    loadhelp: loadhelp,
+    loadhelp: Pointer,
 
     // The exact purpose of this command is unknown, but it is related to the blue help-text box that appears on the bottom of the screen when the Main Menu is opened.
-    unloadhelp: arg0,
+    unloadhelp: Arg0,
 
     // After using this command, all standard message boxes will use the signpost frame.
-    signmsg: arg0,
+    signmsg: Arg0,
 
     // Ends the effects of signmsg, returning message box frames to normal.
-    normalmsg: arg0,
+    normalmsg: Arg0,
 
     // Compares the value of a hidden variable to a dword.
     comparehiddenvar: comparehiddenvar,
 
     // Makes the Pokemon in the specified slot of the player's party obedient. It will not randomly disobey orders in battle.
-    setmonobedient: setmonobedient,
+    setmonobedient: Slot,
 
     // Checks if the Pokemon in the specified slot of the player's party is obedient. If the Pokemon is disobedient, 0x0001 is written to script variable 0x800D (LASTRESULT). If the Pokemon is obedient (or if the specified slot is empty or invalid), 0x0000 is written.
-    checkmonobedience: checkmonobedience,
+    checkmonobedience: Slot,
 
     // Depending on factors I haven't managed to understand yet, this command may cause script execution to jump to the offset specified by the pointer at 0x020375C0.
-    execram: arg0,
+    execram: Arg0,
 
     // Sets worldmapflag to 1. This allows the player to Fly to the corresponding map, if that map has a flightspot.
     setworldmapflag: setworldmapflag,
 
     // Clone of warpteleport? It is apparently only used in FR/LG, and only with specials.[source]
-    warpteleport2: warpteleport2,
+    warpteleport2: Warp,
 
     // Changes the location where the player caught the Pokemon in the specified slot of their party.
     setmonmetlocation: setmonmetlocation,
     mossdeepgym1: mossdeepgym1,
-    mossdeepgym2: arg0,
+    mossdeepgym2: Arg0,
 
     // In FireRed, this command is a nop.
     mossdeepgym3: mossdeepgym3,
-    mossdeepgym4: arg0,
+    mossdeepgym4: Arg0,
     warp7: warp7,
-    cmd_d8: arg0,
-    cmd_d9: arg0,
-    hidebox2: arg0,
-    message3: message3,
+    cmd_d8: Arg0,
+    cmd_d9: Arg0,
+    hidebox2: Arg0,
+    message3: Pointer,
     fadescreenswapbuffers: fadescreenswapbuffers,
     buffertrainerclassname: buffertrainerclassname,
     buffertrainername: buffertrainername,
-    pokenavcall: pokenavcall,
+    pokenavcall: Pointer,
     warp8: warp8,
     buffercontesttypestring: buffercontesttypestring,
 
@@ -861,389 +861,237 @@ pub const Command = extern union {
         bufferitemnameplural = 0xe2,
     };
 
-    pub const arg0 = extern struct {
-        kind: Kind,
+    pub const Arg0 = extern struct {
+        kind: Kind align(1),
     };
-    pub const call = extern struct {
-        kind: Kind,
-        destination: lu32,
+    pub const Jump = extern struct {
+        kind: Kind align(1),
+        destination: lu32 align(1),
     };
-    pub const goto = extern struct {
-        kind: Kind,
-        destination: lu32,
+    pub const CondJump = extern struct {
+        kind: Kind align(1),
+        condition: u8 align(1),
+        destination: lu32 align(1),
     };
-    pub const goto_if = extern struct {
-        kind: Kind,
-        condition: u8,
-        destination: lu32,
-    };
-    pub const call_if = extern struct {
-        kind: Kind,
-        condition: u8,
-        destination: lu32,
-    };
-    pub const gotostd = extern struct {
-        kind: Kind,
-        function: u8,
-    };
-    pub const callstd = extern struct {
-        kind: Kind,
-        function: u8,
-    };
-    pub const gotostd_if = extern struct {
-        kind: Kind,
-        condition: u8,
-        function: u8,
-    };
-    pub const callstd_if = extern struct {
-        kind: Kind,
-        condition: u8,
-        function: u8,
+    pub fn Func(comptime T: type) type {
+        return extern struct {
+            kind: Kind align(1),
+            function: T align(1),
+        };
+    }
+    pub const CondFunc = extern struct {
+        kind: Kind align(1),
+        condition: u8 align(1),
+        function: u8 align(1),
     };
     pub const setmysteryeventstatus = extern struct {
-        kind: Kind,
-        value: u8,
+        kind: Kind align(1),
+        value: u8 align(1),
     };
     pub const loadword = extern struct {
-        kind: Kind,
-        destination: u8,
-        value: gen3.Ptr([*:0xff]u8),
+        kind: Kind align(1),
+        destination: u8 align(1),
+        value: gen3.Ptr([*:0xff]u8) align(1),
     };
     pub const loadbyte = extern struct {
-        kind: Kind,
-        destination: u8,
-        value: u8,
+        kind: Kind align(1),
+        destination: u8 align(1),
+        value: u8 align(1),
     };
     pub const writebytetoaddr = extern struct {
-        kind: Kind,
-        value: u8,
-        offset: lu32,
+        kind: Kind align(1),
+        value: u8 align(1),
+        offset: lu32 align(1),
     };
-    pub const loadbytefromaddr = extern struct {
-        kind: Kind,
-        destination: u8,
-        source: lu32,
-    };
+    pub fn DestSrc(comptime Dst: type, comptime Src: type) type {
+        return extern struct {
+            kind: Kind align(1),
+            dest: Dst align(1),
+            src: Src align(1),
+        };
+    }
     pub const setptrbyte = extern struct {
-        kind: Kind,
-        source: u8,
-        destination: lu32,
+        kind: Kind align(1),
+        source: u8 align(1),
+        destination: lu32 align(1),
     };
-    pub const copylocal = extern struct {
-        kind: Kind,
-        destination: u8,
-        source: u8,
+    pub const DestVal = extern struct {
+        kind: Kind align(1),
+        destination: lu16 align(1),
+        value: lu16 align(1),
     };
-    pub const copybyte = extern struct {
-        kind: Kind,
-        destination: lu32,
-        source: lu32,
-    };
-    pub const setvar = extern struct {
-        kind: Kind,
-        destination: lu16,
-        value: lu16,
-    };
-    pub const addvar = extern struct {
-        kind: Kind,
-        destination: lu16,
-        value: lu16,
-    };
-    pub const subvar = extern struct {
-        kind: Kind,
-        destination: lu16,
-        value: lu16,
-    };
-    pub const copyvar = extern struct {
-        kind: Kind,
-        destination: lu16,
-        source: lu16,
-    };
-    pub const setorcopyvar = extern struct {
-        kind: Kind,
-        destination: lu16,
-        source: lu16,
-    };
-    pub const compare_local_to_local = extern struct {
-        kind: Kind,
-        byte1: u8,
-        byte2: u8,
-    };
-    pub const compare_local_to_value = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-    };
-    pub const compare_local_to_addr = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu32,
-    };
-    pub const compare_addr_to_local = extern struct {
-        kind: Kind,
-        a: lu32,
-        b: u8,
-    };
-    pub const compare_addr_to_value = extern struct {
-        kind: Kind,
-        a: lu32,
-        b: u8,
-    };
-    pub const compare_addr_to_addr = extern struct {
-        kind: Kind,
-        a: lu32,
-        b: lu32,
-    };
+    pub fn AB(comptime A: type, comptime B: type) type {
+        return extern struct {
+            kind: Kind align(1),
+            a: A align(1),
+            b: B align(1),
+        };
+    }
     pub const compare_var_to_value = extern struct {
-        kind: Kind,
-        @"var": lu16,
-        value: lu16,
+        kind: Kind align(1),
+        @"var": lu16 align(1),
+        value: lu16 align(1),
     };
     pub const compare_var_to_var = extern struct {
-        kind: Kind,
-        var1: lu16,
-        var2: lu16,
-    };
-    pub const callnative = extern struct {
-        kind: Kind,
-        func: lu32,
-    };
-    pub const gotonative = extern struct {
-        kind: Kind,
-        func: lu32,
-    };
-    pub const special = extern struct {
-        kind: Kind,
-        special_function: lu16,
+        kind: Kind align(1),
+        var1: lu16 align(1),
+        var2: lu16 align(1),
     };
     pub const specialvar = extern struct {
-        kind: Kind,
-        output: lu16,
-        special_function: lu16,
+        kind: Kind align(1),
+        output: lu16 align(1),
+        special_function: lu16 align(1),
     };
     pub const delay = extern struct {
-        kind: Kind,
-        time: lu16,
+        kind: Kind align(1),
+        time: lu16 align(1),
     };
-    pub const setflag = extern struct {
-        kind: Kind,
-        a: lu16,
-    };
-    pub const clearflag = extern struct {
-        kind: Kind,
-        a: lu16,
-    };
-    pub const checkflag = extern struct {
-        kind: Kind,
-        a: lu16,
+    pub const Arg1 = extern struct {
+        kind: Kind align(1),
+        arg: lu16 align(1),
     };
     pub const initclock = extern struct {
-        kind: Kind,
-        hour: lu16,
-        minute: lu16,
-    };
-    pub const playse = extern struct {
-        kind: Kind,
-        sound_number: lu16,
-    };
-    pub const playfanfare = extern struct {
-        kind: Kind,
-        fanfare_number: lu16,
+        kind: Kind align(1),
+        hour: lu16 align(1),
+        minute: lu16 align(1),
     };
     pub const playbgm = extern struct {
-        kind: Kind,
-        song_number: lu16,
-        unknown: u8,
+        kind: Kind align(1),
+        song_number: lu16 align(1),
+        unknown: u8 align(1),
     };
-    pub const savebgm = extern struct {
-        kind: Kind,
-        song_number: lu16,
+    pub const Song = extern struct {
+        kind: Kind align(1),
+        song_number: lu16 align(1),
     };
-    pub const fadenewbgm = extern struct {
-        kind: Kind,
-        song_number: lu16,
+    pub const Speed = extern struct {
+        kind: Kind align(1),
+        speed: u8 align(1),
     };
-    pub const fadeoutbgm = extern struct {
-        kind: Kind,
-        speed: u8,
-    };
-    pub const fadeinbgm = extern struct {
-        kind: Kind,
-        speed: u8,
-    };
-    pub const warp = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
-    };
-    pub const warpsilent = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
-    };
-    pub const warpdoor = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
+    pub const Warp = extern struct {
+        kind: Kind align(1),
+        map: lu16 align(1),
+        warp: u8 align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const warphole = extern struct {
-        kind: Kind,
-        map: lu16,
-    };
-    pub const warpteleport = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
-    };
-    pub const setwarp = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
-    };
-    pub const setdynamicwarp = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
-    };
-    pub const setdivewarp = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
-    };
-    pub const setholewarp = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        map: lu16 align(1),
     };
     pub const getplayerxy = extern struct {
-        kind: Kind,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const additem = extern struct {
-        kind: Kind,
-        index: lu16,
-        quantity: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        quantity: lu16 align(1),
     };
     pub const removeitem = extern struct {
-        kind: Kind,
-        index: lu16,
-        quantity: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        quantity: lu16 align(1),
     };
     pub const checkitemspace = extern struct {
-        kind: Kind,
-        index: lu16,
-        quantity: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        quantity: lu16 align(1),
     };
     pub const checkitem = extern struct {
-        kind: Kind,
-        index: lu16,
-        quantity: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        quantity: lu16 align(1),
     };
     pub const checkitemtype = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const givepcitem = extern struct {
-        kind: Kind,
-        index: lu16,
-        quantity: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        quantity: lu16 align(1),
     };
     pub const checkpcitem = extern struct {
-        kind: Kind,
-        index: lu16,
-        quantity: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        quantity: lu16 align(1),
     };
     pub const givedecoration = extern struct {
-        kind: Kind,
-        decoration: lu16,
+        kind: Kind align(1),
+        decoration: lu16 align(1),
     };
     pub const takedecoration = extern struct {
-        kind: Kind,
-        decoration: lu16,
+        kind: Kind align(1),
+        decoration: lu16 align(1),
     };
     pub const checkdecor = extern struct {
-        kind: Kind,
-        decoration: lu16,
+        kind: Kind align(1),
+        decoration: lu16 align(1),
     };
     pub const checkdecorspace = extern struct {
-        kind: Kind,
-        decoration: lu16,
+        kind: Kind align(1),
+        decoration: lu16 align(1),
     };
     pub const applymovement = extern struct {
-        kind: Kind,
-        index: lu16,
-        movements: lu32,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        movements: lu32 align(1),
     };
     pub const applymovementmap = extern struct {
-        kind: Kind,
-        index: lu16,
-        movements: lu32,
-        map: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        movements: lu32 align(1),
+        map: lu16 align(1),
     };
     pub const waitmovement = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const waitmovementmap = extern struct {
-        kind: Kind,
-        index: lu16,
-        map: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        map: lu16 align(1),
     };
     pub const removeobject = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const removeobjectmap = extern struct {
-        kind: Kind,
-        index: lu16,
-        map: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        map: lu16 align(1),
     };
     pub const addobject = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const addobjectmap = extern struct {
-        kind: Kind,
-        index: lu16,
-        map: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        map: lu16 align(1),
     };
     pub const setobjectxy = extern struct {
-        kind: Kind,
-        index: lu16,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const showobjectat = extern struct {
-        kind: Kind,
-        index: lu16,
-        map: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        map: lu16 align(1),
     };
     pub const hideobjectat = extern struct {
-        kind: Kind,
-        index: lu16,
-        map: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        map: lu16 align(1),
     };
     pub const turnobject = extern struct {
-        kind: Kind,
-        index: lu16,
-        direction: u8,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        direction: u8 align(1),
     };
 
     pub const TrainerBattleType = enum(u8) {
@@ -1263,607 +1111,530 @@ pub const Command = extern union {
     };
 
     pub const trainerbattle = extern struct {
-        kind: Kind,
-        pointers: packed union {
+        kind: Kind align(1),
+        pointers: extern union {
             type: TrainerBattleType,
             trainer_battle_single: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
             },
             trainer_battle_continue_script_no_music: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
-                pointer3: lu32, // event script
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
+                pointer3: lu32 align(1), // event script
             },
             trainer_battle_continue_script: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
-                pointer3: lu32, // event script
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
+                pointer3: lu32 align(1), // event script
             },
             trainer_battle_single_no_intro_text: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
             },
             trainer_battle_double: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
-                pointer3: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
+                pointer3: lu32 align(1), // text
             },
             trainer_battle_rematch: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
             },
             trainer_battle_continue_script_double: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
-                pointer3: lu32, // text
-                pointer4: lu32, // event script
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
+                pointer3: lu32 align(1), // text
+                pointer4: lu32 align(1), // event script
             },
             trainer_battle_rematch_double: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
-                pointer3: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
+                pointer3: lu32 align(1), // text
             },
             trainer_battle_continue_script_double_no_music: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
-                pointer3: lu32, // text
-                pointer4: lu32, // event script
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
+                pointer3: lu32 align(1), // text
+                pointer4: lu32 align(1), // event script
             },
             trainer_battle_pyramid: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
             },
             trainer_battle_set_trainer_a: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
             },
             trainer_battle_set_trainer_b: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
             },
             trainer_battle12: extern struct {
-                type: TrainerBattleType,
-                trainer: lu16,
-                local_id: lu16,
-                pointer1: lu32, // text
-                pointer2: lu32, // text
+                type: TrainerBattleType align(1),
+                trainer: lu16 align(1),
+                local_id: lu16 align(1),
+                pointer1: lu32 align(1), // text
+                pointer2: lu32 align(1), // text
             },
         },
     };
-    pub const checktrainerflag = extern struct {
-        kind: Kind,
-        trainer: lu16,
-    };
-    pub const settrainerflag = extern struct {
-        kind: Kind,
-        trainer: lu16,
-    };
-    pub const cleartrainerflag = extern struct {
-        kind: Kind,
-        trainer: lu16,
+    pub const Trainer = extern struct {
+        kind: Kind align(1),
+        trainer: lu16 align(1),
     };
     pub const setobjectxyperm = extern struct {
-        kind: Kind,
-        index: lu16,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const moveobjectoffscreen = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const setobjectmovementtype = extern struct {
-        kind: Kind,
-        word: lu16,
-        byte: u8,
+        kind: Kind align(1),
+        word: lu16 align(1),
+        byte: u8 align(1),
     };
     pub const message = extern struct {
-        kind: Kind,
-        text: gen3.Ptr([*:0xff]u8),
+        kind: Kind align(1),
+        text: gen3.Ptr([*:0xff]u8) align(1),
     };
     pub const yesnobox = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
+        kind: Kind align(1),
+        x: u8 align(1),
+        y: u8 align(1),
     };
     pub const multichoice = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
-        list: u8,
-        b: u8,
+        kind: Kind align(1),
+        x: u8 align(1),
+        y: u8 align(1),
+        list: u8 align(1),
+        b: u8 align(1),
     };
     pub const multichoicedefault = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
-        list: u8,
-        default: u8,
-        b: u8,
+        kind: Kind align(1),
+        x: u8 align(1),
+        y: u8 align(1),
+        list: u8 align(1),
+        default: u8 align(1),
+        b: u8 align(1),
     };
     pub const multichoicegrid = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
-        list: u8,
-        per_row: u8,
-        b: u8,
+        kind: Kind align(1),
+        x: u8 align(1),
+        y: u8 align(1),
+        list: u8 align(1),
+        per_row: u8 align(1),
+        b: u8 align(1),
     };
     pub const erasebox = extern struct {
-        kind: Kind,
-        byte1: u8,
-        byte2: u8,
-        byte3: u8,
-        byte4: u8,
+        kind: Kind align(1),
+        byte1: u8 align(1),
+        byte2: u8 align(1),
+        byte3: u8 align(1),
+        byte4: u8 align(1),
     };
     pub const drawboxtext = extern struct {
-        kind: Kind,
-        byte1: u8,
-        byte2: u8,
-        byte3: u8,
-        byte4: u8,
+        kind: Kind align(1),
+        byte1: u8 align(1),
+        byte2: u8 align(1),
+        byte3: u8 align(1),
+        byte4: u8 align(1),
     };
     pub const drawmonpic = extern struct {
-        kind: Kind,
-        species: lu16,
-        x: u8,
-        y: u8,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        x: u8 align(1),
+        y: u8 align(1),
     };
     pub const drawcontestwinner = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const braillemessage = extern struct {
-        kind: Kind,
-        text: lu32,
+        kind: Kind align(1),
+        text: lu32 align(1),
     };
     pub const givemon = extern struct {
-        kind: Kind,
-        species: lu16,
-        level: u8,
-        item: lu16,
-        unknown1: lu32,
-        unknown2: lu32,
-        unknown3: u8,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        level: u8 align(1),
+        item: lu16 align(1),
+        unknown1: lu32 align(1),
+        unknown2: lu32 align(1),
+        unknown3: u8 align(1),
     };
     pub const giveegg = extern struct {
-        kind: Kind,
-        species: lu16,
+        kind: Kind align(1),
+        species: lu16 align(1),
     };
     pub const setmonmove = extern struct {
-        kind: Kind,
-        index: u8,
-        slot: u8,
-        move: lu16,
+        kind: Kind align(1),
+        index: u8 align(1),
+        slot: u8 align(1),
+        move: lu16 align(1),
     };
     pub const checkpartymove = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const bufferspeciesname = extern struct {
-        kind: Kind,
-        out: u8,
-        species: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        species: lu16 align(1),
     };
     pub const bufferleadmonspeciesname = extern struct {
-        kind: Kind,
-        out: u8,
+        kind: Kind align(1),
+        out: u8 align(1),
     };
     pub const bufferpartymonnick = extern struct {
-        kind: Kind,
-        out: u8,
-        slot: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        slot: lu16 align(1),
     };
     pub const bufferitemname = extern struct {
-        kind: Kind,
-        out: u8,
-        item: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        item: lu16 align(1),
     };
     pub const bufferdecorationname = extern struct {
-        kind: Kind,
-        out: u8,
-        decoration: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        decoration: lu16 align(1),
     };
     pub const buffermovename = extern struct {
-        kind: Kind,
-        out: u8,
-        move: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        move: lu16 align(1),
     };
     pub const buffernumberstring = extern struct {
-        kind: Kind,
-        out: u8,
-        input: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        input: lu16 align(1),
     };
     pub const bufferstdstring = extern struct {
-        kind: Kind,
-        out: u8,
-        index: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        index: lu16 align(1),
     };
     pub const bufferstring = extern struct {
-        kind: Kind,
-        out: u8,
-        offset: lu32,
+        kind: Kind align(1),
+        out: u8 align(1),
+        offset: lu32 align(1),
     };
     pub const pokemart = extern struct {
-        kind: Kind,
-        products: lu32,
+        kind: Kind align(1),
+        products: lu32 align(1),
     };
     pub const pokemartdecoration = extern struct {
-        kind: Kind,
-        products: lu32,
+        kind: Kind align(1),
+        products: lu32 align(1),
     };
     pub const pokemartdecoration2 = extern struct {
-        kind: Kind,
-        products: lu32,
+        kind: Kind align(1),
+        products: lu32 align(1),
     };
     pub const playslotmachine = extern struct {
-        kind: Kind,
-        word: lu16,
+        kind: Kind align(1),
+        word: lu16 align(1),
     };
     pub const setberrytree = extern struct {
-        kind: Kind,
-        tree_id: u8,
-        berry: u8,
-        growth_stage: u8,
+        kind: Kind align(1),
+        tree_id: u8 align(1),
+        berry: u8 align(1),
+        growth_stage: u8 align(1),
     };
     pub const random = extern struct {
-        kind: Kind,
-        limit: lu16,
+        kind: Kind align(1),
+        limit: lu16 align(1),
     };
     pub const givemoney = extern struct {
-        kind: Kind,
-        value: lu32,
-        check: u8,
+        kind: Kind align(1),
+        value: lu32 align(1),
+        check: u8 align(1),
     };
     pub const takemoney = extern struct {
-        kind: Kind,
-        value: lu32,
-        check: u8,
+        kind: Kind align(1),
+        value: lu32 align(1),
+        check: u8 align(1),
     };
     pub const checkmoney = extern struct {
-        kind: Kind,
-        value: lu32,
-        check: u8,
+        kind: Kind align(1),
+        value: lu32 align(1),
+        check: u8 align(1),
     };
     pub const showmoneybox = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
-        check: u8,
+        kind: Kind align(1),
+        x: u8 align(1),
+        y: u8 align(1),
+        check: u8 align(1),
     };
     pub const updatemoneybox = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
+        kind: Kind align(1),
+        x: u8 align(1),
+        y: u8 align(1),
     };
     pub const getpricereduction = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const fadescreen = extern struct {
-        kind: Kind,
-        effect: u8,
+        kind: Kind align(1),
+        effect: u8 align(1),
     };
     pub const fadescreenspeed = extern struct {
-        kind: Kind,
-        effect: u8,
-        speed: u8,
+        kind: Kind align(1),
+        effect: u8 align(1),
+        speed: u8 align(1),
     };
     pub const setflashradius = extern struct {
-        kind: Kind,
-        word: lu16,
+        kind: Kind align(1),
+        word: lu16 align(1),
     };
     pub const animateflash = extern struct {
-        kind: Kind,
-        byte: u8,
-    };
-    pub const messageautoscroll = extern struct {
-        kind: Kind,
-        pointer: lu32,
+        kind: Kind align(1),
+        byte: u8 align(1),
     };
     pub const dofieldeffect = extern struct {
-        kind: Kind,
-        animation: lu16,
+        kind: Kind align(1),
+        animation: lu16 align(1),
     };
     pub const setfieldeffectargument = extern struct {
-        kind: Kind,
-        argument: u8,
-        param: lu16,
+        kind: Kind align(1),
+        argument: u8 align(1),
+        param: lu16 align(1),
     };
     pub const waitfieldeffect = extern struct {
-        kind: Kind,
-        animation: lu16,
+        kind: Kind align(1),
+        animation: lu16 align(1),
     };
     pub const setrespawn = extern struct {
-        kind: Kind,
-        heallocation: lu16,
+        kind: Kind align(1),
+        heallocation: lu16 align(1),
     };
     pub const playmoncry = extern struct {
-        kind: Kind,
-        species: lu16,
-        effect: lu16,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        effect: lu16 align(1),
     };
     pub const setmetatile = extern struct {
-        kind: Kind,
-        x: lu16,
-        y: lu16,
-        metatile_number: lu16,
-        tile_attrib: lu16,
+        kind: Kind align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
+        metatile_number: lu16 align(1),
+        tile_attrib: lu16 align(1),
     };
     pub const setweather = extern struct {
-        kind: Kind,
-        type: lu16,
+        kind: Kind align(1),
+        type: lu16 align(1),
     };
     pub const setstepcallback = extern struct {
-        kind: Kind,
-        subroutine: u8,
+        kind: Kind align(1),
+        subroutine: u8 align(1),
     };
     pub const setmaplayoutindex = extern struct {
-        kind: Kind,
-        index: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
     };
     pub const setobjectpriority = extern struct {
-        kind: Kind,
-        index: lu16,
-        map: lu16,
-        priority: u8,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        map: lu16 align(1),
+        priority: u8 align(1),
     };
     pub const resetobjectpriority = extern struct {
-        kind: Kind,
-        index: lu16,
-        map: lu16,
+        kind: Kind align(1),
+        index: lu16 align(1),
+        map: lu16 align(1),
     };
     pub const createvobject = extern struct {
-        kind: Kind,
-        sprite: u8,
-        byte2: u8,
-        x: lu16,
-        y: lu16,
-        elevation: u8,
-        direction: u8,
+        kind: Kind align(1),
+        sprite: u8 align(1),
+        byte2: u8 align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
+        elevation: u8 align(1),
+        direction: u8 align(1),
     };
     pub const turnvobject = extern struct {
-        kind: Kind,
-        index: u8,
-        direction: u8,
+        kind: Kind align(1),
+        index: u8 align(1),
+        direction: u8 align(1),
     };
     pub const opendoor = extern struct {
-        kind: Kind,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const closedoor = extern struct {
-        kind: Kind,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const setdooropen = extern struct {
-        kind: Kind,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const setdoorclosed = extern struct {
-        kind: Kind,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        x: lu16 align(1),
+        y: lu16 align(1),
     };
     pub const addelevmenuitem = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const checkcoins = extern struct {
-        kind: Kind,
-        out: lu16,
+        kind: Kind align(1),
+        out: lu16 align(1),
     };
     pub const givecoins = extern struct {
-        kind: Kind,
-        count: lu16,
+        kind: Kind align(1),
+        count: lu16 align(1),
     };
     pub const takecoins = extern struct {
-        kind: Kind,
-        count: lu16,
+        kind: Kind align(1),
+        count: lu16 align(1),
     };
     pub const setwildbattle = extern struct {
-        kind: Kind,
-        species: lu16,
-        level: u8,
-        item: lu16,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        level: u8 align(1),
+        item: lu16 align(1),
     };
-    pub const setvaddress = extern struct {
-        kind: Kind,
-        pointer: lu32,
-    };
-    pub const vgoto = extern struct {
-        kind: Kind,
-        pointer: lu32,
-    };
-    pub const vcall = extern struct {
-        kind: Kind,
-        pointer: lu32,
-    };
-    pub const vgoto_if = extern struct {
-        kind: Kind,
-        byte: u8,
-        pointer: lu32,
-    };
-    pub const vcall_if = extern struct {
-        kind: Kind,
-        byte: u8,
-        pointer: lu32,
-    };
-    pub const vmessage = extern struct {
-        kind: Kind,
-        pointer: lu32,
-    };
-    pub const vloadptr = extern struct {
-        kind: Kind,
-        pointer: lu32,
-    };
-    pub const vbufferstring = extern struct {
-        kind: Kind,
-        byte: u8,
-        pointer: lu32,
-    };
-    pub const showcoinsbox = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
-    };
-    pub const hidecoinsbox = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
-    };
-    pub const updatecoinsbox = extern struct {
-        kind: Kind,
-        x: u8,
-        y: u8,
+
+    pub const Coord = extern struct {
+        kind: Kind align(1),
+        x: u8 align(1),
+        y: u8 align(1),
     };
     pub const incrementgamestat = extern struct {
-        kind: Kind,
-        stat: u8,
-    };
-    pub const setescapewarp = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        stat: u8 align(1),
     };
     pub const bufferboxname = extern struct {
-        kind: Kind,
-        out: u8,
-        box: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        box: lu16 align(1),
     };
     pub const textcolor = extern struct {
-        kind: Kind,
-        color: u8,
-    };
-    pub const loadhelp = extern struct {
-        kind: Kind,
-        pointer: lu32,
+        kind: Kind align(1),
+        color: u8 align(1),
     };
     pub const comparehiddenvar = extern struct {
-        kind: Kind,
-        a: u8,
-        value: lu32,
+        kind: Kind align(1),
+        a: u8 align(1),
+        value: lu32 align(1),
     };
-    pub const setmonobedient = extern struct {
-        kind: Kind,
-        slot: lu16,
-    };
-    pub const checkmonobedience = extern struct {
-        kind: Kind,
-        slot: lu16,
+    pub const Slot = extern struct {
+        kind: Kind align(1),
+        slot: lu16 align(1),
     };
     pub const setworldmapflag = extern struct {
-        kind: Kind,
-        worldmapflag: lu16,
-    };
-    pub const warpteleport2 = extern struct {
-        kind: Kind,
-        map: lu16,
-        warp: u8,
-        x: lu16,
-        y: lu16,
+        kind: Kind align(1),
+        worldmapflag: lu16 align(1),
     };
     pub const setmonmetlocation = extern struct {
-        kind: Kind,
-        slot: lu16,
-        location: u8,
+        kind: Kind align(1),
+        slot: lu16 align(1),
+        location: u8 align(1),
     };
     pub const mossdeepgym1 = extern struct {
-        kind: Kind,
-        unknown: lu16,
+        kind: Kind align(1),
+        unknown: lu16 align(1),
     };
     pub const mossdeepgym3 = extern struct {
-        kind: Kind,
-        @"var": lu16,
+        kind: Kind align(1),
+        @"var": lu16 align(1),
     };
     pub const warp7 = extern struct {
-        kind: Kind,
-        map: lu16,
-        byte: u8,
-        word1: lu16,
-        word2: lu16,
-    };
-    pub const message3 = extern struct {
-        kind: Kind,
-        pointer: lu32,
+        kind: Kind align(1),
+        map: lu16 align(1),
+        byte: u8 align(1),
+        word1: lu16 align(1),
+        word2: lu16 align(1),
     };
     pub const fadescreenswapbuffers = extern struct {
-        kind: Kind,
-        byte: u8,
+        kind: Kind align(1),
+        byte: u8 align(1),
     };
     pub const buffertrainerclassname = extern struct {
-        kind: Kind,
-        out: u8,
-        class: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        class: lu16 align(1),
     };
     pub const buffertrainername = extern struct {
-        kind: Kind,
-        out: u8,
-        trainer: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        trainer: lu16 align(1),
     };
-    pub const pokenavcall = extern struct {
-        kind: Kind,
-        pointer: lu32,
+    pub const Pointer = extern struct {
+        kind: Kind align(1),
+        pointer: lu32 align(1),
     };
     pub const warp8 = extern struct {
-        kind: Kind,
-        map: lu16,
-        byte: u8,
-        word1: lu16,
-        word2: lu16,
+        kind: Kind align(1),
+        map: lu16 align(1),
+        byte: u8 align(1),
+        word1: lu16 align(1),
+        word2: lu16 align(1),
     };
     pub const buffercontesttypestring = extern struct {
-        kind: Kind,
-        out: u8,
-        word: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        word: lu16 align(1),
     };
     pub const bufferitemnameplural = extern struct {
-        kind: Kind,
-        out: u8,
-        item: lu16,
-        quantity: lu16,
+        kind: Kind align(1),
+        out: u8 align(1),
+        item: lu16 align(1),
+        quantity: lu16 align(1),
     };
+
+    comptime {
+        @setEvalBranchQuota(1000000);
+        std.debug.assert(script.isPacked(@This()));
+    }
 };

--- a/src/core/gen4/encodings.zig
+++ b/src/core/gen4/encodings.zig
@@ -1170,5 +1170,6 @@ pub fn decode(reader: anytype, writer: anytype) !void {
 }
 
 pub fn decode2(in: []const u8, writer: anytype) !void {
-    try decode(io.fixedBufferStream(in).reader(), writer);
+    var fbs = io.fixedBufferStream(in);
+    try decode(fbs.reader(), writer);
 }

--- a/src/core/gen4/script.zig
+++ b/src/core/gen4/script.zig
@@ -8,7 +8,7 @@ const li32 = rom.int.li32;
 const lu16 = rom.int.lu16;
 const lu32 = rom.int.lu32;
 
-pub fn getScriptOffsets(data: []const u8) []const li32 {
+pub fn getScriptOffsets(data: []const u8) []align(1) const li32 {
     var len: usize = 0;
     while (true) : (len += 1) {
         const rest = data[len * 4 ..];
@@ -1564,1444 +1564,1444 @@ pub const Command = extern union {
         display_floor = lu16.init(0x347).inner,
     };
     pub const Arg0 = extern struct {
-        kind: Kind,
+        kind: Kind align(1),
     };
     pub const Return2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_a = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
     };
     pub const If = extern struct {
-        kind: Kind,
-        @"var": lu16,
-        nr: lu16,
+        kind: Kind align(1),
+        @"var": lu16 align(1),
+        nr: lu16 align(1),
     };
     pub const If2 = extern struct {
-        kind: Kind,
-        @"var": lu16,
-        nr: lu16,
+        kind: Kind align(1),
+        @"var": lu16 align(1),
+        nr: lu16 align(1),
     };
     pub const CallStandard = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Jump = extern struct {
-        kind: Kind,
-        adr: li32,
+        kind: Kind align(1),
+        adr: li32 align(1),
     };
     pub const Call = extern struct {
-        kind: Kind,
-        adr: li32,
+        kind: Kind align(1),
+        adr: li32 align(1),
     };
     pub const CompareLastResultJump = extern struct {
-        kind: Kind,
-        cond: u8,
-        adr: li32,
+        kind: Kind align(1),
+        cond: u8 align(1),
+        adr: li32 align(1),
     };
     pub const CompareLastResultCall = extern struct {
-        kind: Kind,
-        cond: u8,
-        adr: li32,
+        kind: Kind align(1),
+        cond: u8 align(1),
+        adr: li32 align(1),
     };
     pub const SetFlag = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ClearFlag = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckFlag = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_21 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_22 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetTrainerId = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_24 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ClearTrainerId = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ScriptCmd_AddValue = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ScriptCmd_SubValue = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetVar = extern struct {
-        kind: Kind,
-        destination: lu16,
-        value: lu16,
+        kind: Kind align(1),
+        destination: lu16 align(1),
+        value: lu16 align(1),
     };
     pub const CopyVar = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Message2 = extern struct {
-        kind: Kind,
-        nr: u8,
+        kind: Kind align(1),
+        nr: u8 align(1),
     };
     pub const Message = extern struct {
-        kind: Kind,
-        nr: u8,
+        kind: Kind align(1),
+        nr: u8 align(1),
     };
     pub const Message3 = extern struct {
-        kind: Kind,
-        nr: lu16,
+        kind: Kind align(1),
+        nr: lu16 align(1),
     };
     pub const Message4 = extern struct {
-        kind: Kind,
-        nr: lu16,
+        kind: Kind align(1),
+        nr: lu16 align(1),
     };
     pub const Message5 = extern struct {
-        kind: Kind,
-        nr: u8,
+        kind: Kind align(1),
+        nr: u8 align(1),
     };
     pub const CallMessageBox = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const ColorMsgBox = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const TypeMessageBox = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const CallTextMsgBox = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const StoreMenuStatus = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const YesNoBox = extern struct {
-        kind: Kind,
-        nr: lu16,
+        kind: Kind align(1),
+        nr: lu16 align(1),
     };
     pub const Multi = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: u8,
-        d: u8,
-        e: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: u8 align(1),
+        d: u8 align(1),
+        e: lu16 align(1),
     };
     pub const Multi2 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: u8,
-        d: u8,
-        e: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: u8 align(1),
+        d: u8 align(1),
+        e: lu16 align(1),
     };
     pub const Cmd_42 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
     };
     pub const Multi3 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: u8,
-        d: u8,
-        e: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: u8 align(1),
+        d: u8 align(1),
+        e: lu16 align(1),
     };
     pub const Multi4 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: u8,
-        d: u8,
-        e: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: u8 align(1),
+        d: u8 align(1),
+        e: lu16 align(1),
     };
     pub const TxtMsgScrpMulti = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const PlayFanfare = extern struct {
-        kind: Kind,
-        nr: lu16,
+        kind: Kind align(1),
+        nr: lu16 align(1),
     };
     pub const MultiRow = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const PlayFanfare2 = extern struct {
-        kind: Kind,
-        nr: lu16,
+        kind: Kind align(1),
+        nr: lu16 align(1),
     };
     pub const WaitFanfare = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PlayCry = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Soundfr = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PlaySound = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Stop = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_53 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SwitchMusic = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreSayingLearned = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PlaySound2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_58 = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const CheckSayingLearned = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SwithMusic2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ApplyMovement = extern struct {
-        kind: Kind,
-        a: lu16,
-        adr: lu32,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        adr: lu32 align(1),
     };
     pub const Lock = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Release = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const AddPeople = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const RemovePeople = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const LockCam = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckSpritePosition = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckPersonPosition = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const ContinueFollow = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: u8,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: u8 align(1),
     };
     pub const FollowHero = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const TakeMoney = extern struct {
-        kind: Kind,
-        a: lu32,
+        kind: Kind align(1),
+        a: lu32 align(1),
     };
     pub const CheckMoney = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu32,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu32 align(1),
     };
     pub const ShowMoney = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ShowCoins = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckCoins = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const GiveCoins = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const TakeCoins = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const TakeItem = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const GiveItem = extern struct {
-        kind: Kind,
-        itemid: lu16,
-        quantity: lu16,
-        @"return": lu16,
+        kind: Kind align(1),
+        itemid: lu16 align(1),
+        quantity: lu16 align(1),
+        @"return": lu16 align(1),
     };
     pub const CheckStoreItem = extern struct {
-        kind: Kind,
-        itemid: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        itemid: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckItem = extern struct {
-        kind: Kind,
-        itemid: lu16,
-        quantity: lu16,
-        @"return": lu16,
+        kind: Kind align(1),
+        itemid: lu16 align(1),
+        quantity: lu16 align(1),
+        @"return": lu16 align(1),
     };
     pub const StoreItemTaken = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreItemType = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SendItemType1 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_84 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckUndergroundPcStatus = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_86 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SendItemType2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_88 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_89 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_8a = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_8b = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_8c = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_8d = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_8e = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SendItemType3 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckPokemonParty = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StorePokemonParty = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetPokemonPartyStored = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const GivePokemon = extern struct {
-        kind: Kind,
-        species: lu16,
-        level: lu16,
-        item: lu16,
-        res: lu16,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        level: lu16 align(1),
+        item: lu16 align(1),
+        res: lu16 align(1),
     };
     pub const GiveEgg = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckMove = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckPlaceStored = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_9b = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_a4 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const DressPokemon = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const DisplayDressedPokemon = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const DisplayContestPokemon = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const OpenPcFunction = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const StoreWfcStatus = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StartWfc = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const BattleId = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetVarBattle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckBattleType = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetVarBattle2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ChoosePokeNick = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const FadeScreen = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Warp = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const RockClimbAnimation = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SurfAnimation = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const WaterfallAnimation = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PrepHmEffect = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckBike = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const RideBike = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const RideBike2 = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const GivePokeHiroAnm = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetVarHero = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const SetVariableRival = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const SetVarAlter = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const SetVarPoke = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarItem = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarItemNum = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarAtkItem = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarAtk = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVariableNumber = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarPokeNick = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarObj = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarTrainer = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarWiFiSprite = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const SetVarPokeStored = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
-        c: lu16,
-        d: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: u8 align(1),
     };
     pub const SetVarStrHero = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const SetVarStrRival = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const StoreStarter = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_df = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarItemStored = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarItemStored2 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarSwarmPoke = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const CheckSwarmPoke = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StartBattleAnalysis = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const TrainerBattle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const EndtrainerBattle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const TrainerBattleStored = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const TrainerBattleStored2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckTrainerStatus = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreLeagueTrainer = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckTrainerLost = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckTrainerStatus2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePokePartyDefeated = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ChsFriend = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const WireBattleWait = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const StartOvation = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StopOvation = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_fa = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Cmd_fb = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_fc = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetvarOtherEntry = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_fe = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetvatHiroEntry = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetvarTypeContest = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetvarRankContest = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_104 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_105 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_106 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_107 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePeopleIdContest = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_109 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetvatHiroEntry2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ActPeopleContest = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_10c = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_10d = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_10e = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_10f = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_110 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const FlashContest = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_115 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePokerus = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const WarpMapElevator = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const CheckFloor = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StartLift = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const StoreSinPokemonSeen = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_11f = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreTotPokemonSeen = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreNatPokemonSeen = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetVarTextPokedex = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const WildBattle = extern struct {
-        kind: Kind,
-        species: lu16,
-        level: lu16,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        level: lu16 align(1),
     };
     pub const StarterBattle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckIfHoneySlathered = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreSaveData = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckSaveData = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckDress = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckContestWin = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StorePhotoName = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPtchAppl = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ActPktchAppl = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePoketchApp = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const FriendBT = extern struct {
-        kind: Kind,
-        nr: lu16,
+        kind: Kind align(1),
+        nr: lu16 align(1),
     };
     pub const Cmd_138 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const OpenUnionFunction2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetUnionFunctionId = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetVarUnionMessage = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreYourDecisionUnion = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreOtherDecisionUnion = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckOtherDecisionUnion = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreYourDecisionUnion2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreOtherDecisionUnion2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckOtherDecisionUnion2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Pokemart = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Pokemart1 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Pokemart2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Pokemart3 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ActBike = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckGender = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const UndergroundId = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreWiFiSprite = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ActWiFiSprite = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_157 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckBadge = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const EnableBadge = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const DisableBadge = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckFollow = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_166 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PrepareDoorAnimation = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: u8,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: u8 align(1),
     };
     pub const WaitAction = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const WaitClose = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const OpenDoor = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const CloseDoor = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const StorePDCareNum = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SunishoreGymFunction = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const SunishoreGymFunction2 = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const CheckPartyNumber = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const OpenBerryPouch = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const Cmd_179 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_17a = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_17b = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SetNaturePokemon = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_17d = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_17e = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_17f = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_180 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_181 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckDeoxis = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_183 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_184 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ChangeOwPosition = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SetOwPosition = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const ChangeOwMovement = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ReleaseOw = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetTilePassable = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SetTileLocked = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SetOwsFollow = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_18f = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetSaveData = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePokeMenu2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ChsPokeContest = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const StorePokeContest = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ShowPokeInfo = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePokeMove = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPokeEgg = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ComparePokeNick = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckPartyNumberUnion = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPokePartyHealth = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckPokePartyNumDCare = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckEggUnion = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const UndergroundFunction = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const UndergroundFunction2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const TakeMoneyDCare = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const TakePokemonDCare = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarPokeAndMoneyDCare = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckMoneyDCare = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarPokeAndLevelDCare = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarPokeChosenDCare = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const GivePokeDCare = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const AddPeople2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const RemovePeople2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckMail = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ShowRecordList = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckTime = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckIdPlayer = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const RandomTextStored = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreHappyPoke = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreHappyStatus = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetVarDataDayCare = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const CheckFacePosition = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePokeDCareLove = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckStatusSolaceonEvent = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPokeParty = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CopyPokemonHeight = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetVariablePokemonHeight = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ComparePokemonHeight = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckPokemonHeight = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const StorePokeDelete = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreMoveDelete = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckMoveNumDelete = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreDeleteMove = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckDeleteMove = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SetvarMoveDelete = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const DeActivateLeader = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const HmFunctions = extern struct {
-        kind: Kind,
-        a: packed union {
+        kind: Kind align(1),
+        a: extern union {
             kind: Kind2,
             @"1": extern struct {
-                kind: Kind2,
+                kind: Kind2 align(1),
             },
             @"2": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
         },
 
@@ -3011,289 +3011,289 @@ pub const Command = extern union {
         };
     };
     pub const FlashDuration = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const DefogDuration = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const GiveAccessories = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckAccessories = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_1d4 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const GiveAccessories2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckAccessories2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const BerryPoffin = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetVarBTowerChs = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const BattleRoomResult = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreBTowerData = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CallBTowerFunctions = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const RandomTeamBTower = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const StorePrizeNumBTower = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePeopleIdBTower = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CallBTowerWireFunction = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const StorePChosenWireBTower = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreRankDataWireBTower = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_1e4 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const RandomEvent = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckSinnohPokedex = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckNationalPokedex = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreTrophyPokemon = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_1ef = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_1f0 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckActFossil = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckItemChosen = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CompareItemPokeFossil = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckPokemonLevel = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckIsPokemonPoisoned = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreFurniture = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CopyFurniture = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetBCastleFunctionId = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const BCastleFunctReturn = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
-        c: lu16,
-        d: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: u8 align(1),
     };
     pub const Cmd_200 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckEffectHm = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const GreatMarshFunction = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const BattlePokeColosseum = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const StorePokeColosseumLost = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PokemonPicture = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_20a = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetvarMtCoronet = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const CheckQuicTrineCoordinates = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetvarQuickTrainCoordinates = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const MoveTrainAnm = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const StorePokeNature = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckPokeNature = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const RandomHallowes = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_216 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_217 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ChsRSPoke = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetSPoke = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckSPoke = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ActSwarmPoke = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const Cmd_21d = extern struct {
-        kind: Kind,
-        a: packed union {
+        kind: Kind align(1),
+        a: extern union {
             kind: Kind2,
             @"0": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
             },
             @"1": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
             },
             @"2": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
             },
             @"3": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
             },
             @"4": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
             @"5": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
         },
 
@@ -3307,110 +3307,110 @@ pub const Command = extern union {
         };
     };
     pub const CheckMoveRemember = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StorePokeRemember = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreRememberMove = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const TeachMove = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckTeachMove = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetTradeId = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const CheckPokemonTrade = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const TradeChosenPokemon = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckNatPokedexStatus = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const CheckRibbonNumber = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckRibbon = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const GiveRibbon = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetvarRibbon = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const CheckHappyRibbon = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckPokemart = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckFurniture = extern struct {
-        kind: Kind,
-        a: packed union {
+        kind: Kind align(1),
+        a: extern union {
             kind: Kind2,
             @"0": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
             @"1": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
-                d: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
+                d: lu16 align(1),
             },
             @"2": extern struct {
-                kind: Kind2,
+                kind: Kind2 align(1),
             },
             @"3": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
-                d: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
+                d: lu16 align(1),
             },
             @"4": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
             },
             @"5": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
-                d: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
+                d: lu16 align(1),
             },
             @"6": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
         },
 
@@ -3425,73 +3425,73 @@ pub const Command = extern union {
         };
     };
     pub const Cmd_236 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPhraseBoxInput = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const CheckStatusPhraseBox = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const DecideRules = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckFootStep = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const HealPokemonAnimation = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreElevatorDirection = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ShipAnimation = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const Cmd_23e = extern struct {
-        kind: Kind,
-        a: packed union {
+        kind: Kind align(1),
+        a: extern union {
             kind: Kind2,
             @"1": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
             @"2": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
             @"3": extern struct {
-                kind: Kind2,
-                b: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
             },
             @"5": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
             },
             @"6": extern struct {
-                kind: Kind2,
-                b: lu16,
-                c: lu16,
+                kind: Kind2 align(1),
+                b: lu16 align(1),
+                c: lu16 align(1),
             },
         },
 
@@ -3504,952 +3504,957 @@ pub const Command = extern union {
         };
     };
     pub const StorePhraseBox1W = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const StorePhraseBox2W = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const SetvarPhraseBox1W = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const StoreMtCoronet = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckFirstPokeParty = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPokeType = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckPhraseBoxInput2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const StoreUndTime = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PreparePcAnimation = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const OpenPcAnimation = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const ClosePcAnimation = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const CheckLottoNumber = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CompareLottoNumber = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const SetvarIdPokeBoxes = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const CheckBoxesNumber = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StopGreatMarsh = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPokeCatchingShow = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckCatchingShowRecords = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckElevLgAnm = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckElevPosition = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const MainEvent = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckAccessories3 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const ActDeoxisFormChange = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ChangeFormDeoxis = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckCoombeEvent = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Pokecasino = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckTime2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const RegigigasAnm = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const CresseliaAnm = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckRegi = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckMassage = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const UnownMessageBox = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPCatchingShow = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ShayminAnm = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: u8,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: u8 align(1),
     };
     pub const ThankNameInsert = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetvarShaymin = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const SetvarAccessories2 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_274 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu32,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu32 align(1),
     };
     pub const CheckRecordCasino = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckCoinsCasino = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SrtRandomNum = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPokeLevel2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_279 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const SetvarAmityPokemon = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_27d = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckFirstTimeVShop = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_27f = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetvarIdNumber = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
-        c: u8,
-        d: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
+        c: u8 align(1),
+        d: u8 align(1),
     };
     pub const Cmd_281 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const SetvarUnk = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_283 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckRuinManiac = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckTurnBack = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckUgPeopleNum = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckUgFossilNum = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckUgTrapsNum = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckPoffinItem = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
-        f: lu16,
-        g: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
+        f: lu16 align(1),
+        g: lu16 align(1),
     };
     pub const CheckPoffinCaseStatus = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const UnkFunct2 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const PokemonPartyPicture = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetSoundLearning = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckFirstTimeChampion = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ChoosePokeDCare = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePokeDCare = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_292 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const CheckMasterRank = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ShowBattlePointsBox = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
     };
     pub const TakeBPoints = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckBPoints = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_29c = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ChoiceMulti = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const HMEffect = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CameraBumpEffect = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const DoubleBattle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const ApplyMovement2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2a2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreActHeroFriendCode = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreActOtherFriendCode = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ChsPrizeCasino = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckPlate = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const TakeCoinsCasino = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckCoinsCasino2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const ComparePhraseBoxInput = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const StoreSealNum = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckFollowBattle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2af = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const SetvarSealRandom = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const DarkraiFunction = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2b6 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: u8,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: u8 align(1),
     };
     pub const StorePokeNumParty = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StorePokeNickname = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckBattleUnion = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const CheckWildBattle2 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const StoreTrainerCardStar = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2c0 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2c3 = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const ShowBTowerSome = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const DeleteSavesBFactory = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckVersionGame = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const ShowBArcadeRecors = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const CheckPokeParty2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const CheckPokeCastle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const ActTeamGalacticEvents = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const ChooseWirePokeBCastle = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2d0 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2d1 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2d2 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2d3 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2d4 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2d5 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2d7 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2d8 = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const Cmd_2d9 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2da = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2db = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2dc = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2dd = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2de = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const Cmd_2df = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2e0 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2e1 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2e4 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2e5 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2e6 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2e7 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2e8 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2e9 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2ea = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2eb = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2ec = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Cmd_2ee = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Cmd_2f3 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2f4 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Cmd_2f5 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu32,
-        c: u8,
-        d: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu32 align(1),
+        c: u8 align(1),
+        d: u8 align(1),
     };
     pub const Cmd_2f6 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_2f7 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2f9 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2fa = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2fc = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_2fd = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2fe = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_2ff = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_302 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
-        e: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
+        e: lu16 align(1),
     };
     pub const Cmd_303 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_304 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Cmd_305 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_306 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_307 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_308 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_30a = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_30d = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_30e = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_30f = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_311 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_312 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_313 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_314 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_315 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_317 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
     };
     pub const Cmd_319 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_31a = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_31b = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_31c = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_31d = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_31e = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_321 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_323 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_324 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
-        c: u8,
-        d: u8,
-        e: lu16,
-        f: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
+        c: u8 align(1),
+        d: u8 align(1),
+        e: lu16 align(1),
+        f: lu16 align(1),
     };
     pub const Cmd_325 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_326 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_327 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const PortalEffect = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_329 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Cmd_32a = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_32b = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_32c = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
-        c: lu16,
-        d: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
+        c: lu16 align(1),
+        d: lu16 align(1),
     };
     pub const Cmd_32f = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_333 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_334 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_335 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu32,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu32 align(1),
     };
     pub const Cmd_336 = extern struct {
-        kind: Kind,
-        a: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
     };
     pub const Cmd_337 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_33a = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const Cmd_33c = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_33d = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_33e = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_33f = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_340 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_341 = extern struct {
-        kind: Kind,
-        a: lu16,
-        b: lu16,
+        kind: Kind align(1),
+        a: lu16 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_342 = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const Cmd_343 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_344 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_345 = extern struct {
-        kind: Kind,
-        a: u8,
-        b: lu16,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: lu16 align(1),
     };
     pub const Cmd_346 = extern struct {
-        kind: Kind,
-        a: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
     };
     pub const DisplayFloor = extern struct {
-        kind: Kind,
-        a: u8,
-        b: u8,
+        kind: Kind align(1),
+        a: u8 align(1),
+        b: u8 align(1),
     };
+
+    comptime {
+        @setEvalBranchQuota(1000000);
+        std.debug.assert(script.isPacked(@This()));
+    }
 };

--- a/src/core/gen5/script.zig
+++ b/src/core/gen5/script.zig
@@ -9,7 +9,7 @@ const li32 = rom.int.li32;
 const lu16 = rom.int.lu16;
 const lu32 = rom.int.lu32;
 
-pub fn getScriptOffsets(data: []const u8) []const li32 {
+pub fn getScriptOffsets(data: []const u8) []align(1) const li32 {
     var len: usize = 0;
     while (true) : (len += 1) {
         const rest = data[len * 4 ..];
@@ -49,39 +49,39 @@ pub const Command = extern union {
     end_function: Arg1(lu16),
     logic06: Arg1(lu16),
     logic07: Arg1(lu16),
-    compare_to: CompareTo,
-    store_var: StoreVar,
-    clear_var: ClearVar,
-    unknown_0b: Unknown_0B,
-    unknown_0c: Unknown_0C,
-    unknown_0d: Unknown_0D,
-    unknown_0e: Unknown_0E,
-    unknown_0f: Unknown_0F,
-    store_flag: StoreFlag,
+    compare_to: Value,
+    store_var: Var,
+    clear_var: Var,
+    unknown_0b: Value,
+    unknown_0c: Value,
+    unknown_0d: Value,
+    unknown_0e: Value,
+    unknown_0f: Value,
+    store_flag: Value,
     condition: Condition,
-    unknown_12: Unknown_12,
-    unknown_13: Unknown_13,
-    unknown_14: Unknown_14,
-    unknown_16: Unknown_16,
-    unknown_17: Unknown_17,
-    compare: Compare,
+    unknown_12: Value,
+    unknown_13: Arg2(lu16, lu16),
+    unknown_14: Value,
+    unknown_16: Value,
+    unknown_17: Value,
+    compare: Value2,
     call_std: CallStd,
     return_std: Arg0,
     jump: Jump,
     @"if": If,
-    unknown_21: Unknown_21,
-    unknown_22: Unknown_22,
-    set_flag: SetFlag,
+    unknown_21: Value,
+    unknown_22: Value,
+    set_flag: Value,
     clear_flag: ClearFlag,
     set_var_flag_status: SetVarFlagStatus,
-    set_var_26: SetVar26,
-    set_var_27: SetVar27,
-    set_var_eq_val: SetVarEqVal,
-    set_var_29: SetVar29,
-    set_var_2a: SetVar2A,
-    set_var_2b: SetVar2B,
+    set_var_26: Value2,
+    set_var_27: Value2,
+    set_var_eq_val: SetVarContainer,
+    set_var_29: SetVarContainer,
+    set_var_2a: SetVarContainer,
+    set_var_2b: Value,
     dir_vars: Arg2(lu16, lu16),
-    unknown_2d: Unknown_2D,
+    unknown_2d: Value,
     lock_all: Arg0,
     unlock_all: Arg0,
     wait_moment: Arg0,
@@ -95,10 +95,10 @@ pub const Command = extern union {
     show_message_at: ShowMessageAt,
     close_show_message_at: Arg0,
     message: Message,
-    message2: Message2,
+    message2: Message,
     close_message_k_p: Arg0,
     close_message_k_p2: Arg0,
-    money_box: MoneyBox,
+    money_box: Coord,
     close_money_box: Arg0,
     update_money_box: Arg0,
     bordered_message: BorderedMessage,
@@ -110,67 +110,67 @@ pub const Command = extern union {
     double_message: DoubleMessage,
     angry_message: AngryMessage,
     close_angry_message: Arg0,
-    set_var_hero: SetVarHero,
-    set_var_item: SetVarItem,
-    unknown_4e: unknown_4E,
-    set_var_item2: SetVarItem2,
-    set_var_item3: SetVarItem3,
-    set_var_move: SetVarMove,
-    set_var_bag: SetVarBag,
-    set_var_party_poke: SetVarPartyPoke,
-    set_var_party_poke2: SetVarPartyPoke2,
-    set_var_unknown: SetVar_Unknown,
-    set_var_type: SetVarType,
-    set_var_poke: SetVarPoke,
-    set_var_poke2: SetVarPoke2,
-    set_var_location: SetVarLocation,
-    set_var_poke_nick: SetVarPokeNick,
-    set_var_unknown2: SetVar_Unknown2,
+    set_var_hero: Arg1(u8),
+    set_var_item: ArgValue(u8, lu16),
+    unknown_4e: Arg4(u8, lu16, lu16, u8),
+    set_var_item2: ArgValue(u8, lu16),
+    set_var_item3: ArgValue(u8, lu16),
+    set_var_move: ArgValue(u8, lu16),
+    set_var_bag: ArgValue(u8, lu16),
+    set_var_party_poke: ArgValue(u8, lu16),
+    set_var_party_poke2: ArgValue(u8, lu16),
+    set_var_unknown: ArgValue(u8, lu16),
+    set_var_type: ArgValue(u8, lu16),
+    set_var_poke: ArgValue(u8, lu16),
+    set_var_poke2: ArgValue(u8, lu16),
+    set_var_location: ArgValue(u8, lu16),
+    set_var_poke_nick: ArgValue(u8, lu16),
+    set_var_unknown2: ArgValue(u8, lu16),
     set_var_store_value5_c: SetVarStoreValue5C,
-    set_var_musical_info: SetVarMusicalInfo,
-    set_var_nations: SetVarNations,
-    set_var_activities: SetVarActivities,
-    set_var_power: SetVarPower,
-    set_var_trainer_type: SetVarTrainerType,
-    set_var_trainer_type2: SetVarTrainerType2,
-    set_var_general_word: SetVarGeneralWord,
+    set_var_musical_info: ArgValue(lu16, lu16),
+    set_var_nations: ArgValue(u8, lu16),
+    set_var_activities: ArgValue(u8, lu16),
+    set_var_power: ArgValue(u8, lu16),
+    set_var_trainer_type: ArgValue(u8, lu16),
+    set_var_trainer_type2: ArgValue(u8, lu16),
+    set_var_general_word: ArgValue(u8, lu16),
     apply_movement: ApplyMovement,
     wait_movement: Arg0,
-    store_hero_position: StoreHeroPosition,
-    unknown_67: Unknown_67,
-    store_hero_position2: StoreHeroPosition2,
+    store_hero_position: Coord,
+    unknown_67: Arg2(lu16, lu16),
+    store_hero_position2: Coord,
     store_npc_position: StoreNPCPosition,
     unknown_6a: Unknown_6A,
-    add_npc: AddNPC,
-    remove_npc: RemoveNPC,
+    add_npc: NPC,
+    remove_npc: NPC,
     set_o_w_position: SetOWPosition,
     unknown_6e: Arg1(lu16),
     unknown_6f: Arg1(lu16),
     unknown_70: Unknown_70,
-    unknown_71: Unknown_71,
-    unknown_72: Unknown_72,
-    unknown_73: Unknown_73,
+    unknown_71: Arg3(lu16, lu16, lu16),
+    unknown_72: Arg4(lu16, lu16, lu16, lu16),
+    unknown_73: Arg2(lu16, lu16),
     face_player: Arg0,
-    release: Release,
+    release: NPC,
     release_all: Arg0,
-    lock_77: Lock,
-    unknown_78: Unknown_78,
+    lock_77: NPC,
+    unknown_78: Var,
     unknown_79: Unknown_79,
     move_npc_to: MoveNPCTo,
-    unknown_7c: Unknown_7C,
-    unknown_7d: Unknown_7D,
+    unknown_7c: Arg4(lu16, lu16, lu16, lu16),
+    unknown_7d: Arg4(lu16, lu16, lu16, lu16),
     teleport_up_npc: TeleportUpNPC,
-    unknown_7f: Unknown_7F,
+    unknown_7f: Arg2(lu16, lu16),
     unknown_80: Arg1(lu16),
     unknown_81: Arg0,
-    unknown_82: Unknown_82,
-    set_var83: SetVar83,
-    set_var84: SetVar84,
+    unknown_82: Arg2(lu16, lu16),
+    set_var83: Value,
+    set_var84: Value,
     single_trainer_battle: SingleTrainerBattle,
     double_trainer_battle: DoubleTrainerBattle,
-    unknown_87: Unknown_87,
-    unknown_88: Unknown_88,
-    unknown_8a: Unknown_8A,
+    unknown_87: Arg3(lu16, lu16, lu16),
+    unknown_88: Arg3(lu16, lu16, lu16),
+    unknown_8a: Arg2(lu16, lu16),
     play_trainer_music: PlayTrainerMusic,
     end_battle: Arg0,
     store_battle_result: StoreBattleResult,
@@ -182,9 +182,9 @@ pub const Command = extern union {
     show_cg: Arg1(lu16),
     call_screen_animation: Arg1(lu16),
     disable_trainer: Arg0,
-    d_var90: DVar90,
-    d_var92: DVar92,
-    d_var93: DVar93,
+    d_var90: Arg2(lu16, lu16),
+    d_var92: Arg2(lu16, lu16),
+    d_var93: Arg2(lu16, lu16),
     trainer_battle: TrainerBattle,
     deactivate_trainer_i_d: DeactivateTrainerID,
     unknown_96: Unknown_96,
@@ -195,7 +195,7 @@ pub const Command = extern union {
     unknown_a2: Unknown_A2,
     unknown_a3: Arg1(lu16),
     unknown_a4: Arg1(lu16),
-    unknown_a5: Unknown_A5,
+    unknown_a5: Arg2(lu16, lu16),
     play_sound: PlaySound,
     wait_sound_a7: Arg0,
     wait_sound: Arg0,
@@ -207,15 +207,15 @@ pub const Command = extern union {
     close_multi: Arg0,
     unknown_b1: Arg0,
     multi2: Multi2,
-    fade_screen: FadeScreen,
-    reset_screen: ResetScreen,
-    screen_b5: Screen_B5,
+    fade_screen: Arg4(lu16, lu16, lu16, lu16),
+    reset_screen: Arg3(lu16, lu16, lu16),
+    screen_b5: Arg3(lu16, lu16, lu16),
     take_item: TakeItem,
     check_item_bag_space: CheckItemBagSpace,
     check_item_bag_number: CheckItemBagNumber,
     store_item_count: StoreItemCount,
-    unknown_ba: Unknown_BA,
-    unknown_bb: Unknown_BB,
+    unknown_ba: Arg4(lu16, lu16, lu16, lu16),
+    unknown_bb: Arg2(lu16, lu16),
     unknown_bc: Arg1(lu16),
     warp: Warp,
     teleport_warp: TeleportWarp,
@@ -225,21 +225,21 @@ pub const Command = extern union {
     teleport_warp2: TeleportWarp2,
     surf_animation: Arg0,
     special_animation: Arg1(lu16),
-    special_animation2: SpecialAnimation2,
-    call_animation: CallAnimation,
-    store_random_number: StoreRandomNumber,
+    special_animation2: Arg2(lu16, lu16),
+    call_animation: Arg2(lu16, lu16),
+    store_random_number: Arg2(lu16, lu16),
     store_var_item: Arg1(lu16),
     store_var_cd: Arg1(lu16),
     store_var_ce: Arg1(lu16),
     store_var_cf: Arg1(lu16),
     store_date: StoreDate,
-    store_d1: Store_D1,
+    store_d1: Arg2(lu16, lu16),
     store_d2: Arg1(lu16),
     store_d3: Arg1(lu16),
     store_birth_day: StoreBirthDay,
     store_badge: StoreBadge,
-    set_badge: SetBadge,
-    store_badge_number: StoreBadgeNumber,
+    set_badge: Badge,
+    store_badge_number: Badge,
     store_version: Arg1(lu16),
     store_gender: Arg1(lu16),
     activate_key_item: Arg1(lu16),
@@ -588,838 +588,466 @@ pub const Command = extern union {
     };
 
     pub const Arg0 = extern struct {
-        kind: Kind,
+        kind: Kind align(1),
     };
     pub fn Arg1(comptime T: type) type {
         return extern struct {
-            kind: Kind,
-            arg: T,
+            kind: Kind align(1),
+            arg: T align(1),
         };
     }
+
     pub fn Arg2(comptime T1: type, comptime T2: type) type {
         return extern struct {
-            kind: Kind,
-            arg1: T1,
-            args2: T2,
+            kind: Kind align(1),
+            arg1: T1 align(1),
+            arg2: T2 align(1),
         };
     }
     pub fn Arg3(comptime T1: type, comptime T2: type, comptime T3: type) type {
         return extern struct {
-            kind: Kind,
-            arg1: T1,
-            args2: T2,
-            args3: T3,
+            kind: Kind align(1),
+            arg1: T1 align(1),
+            arg2: T2 align(1),
+            arg3: T3 align(1),
         };
     }
     pub fn Arg4(comptime T1: type, comptime T2: type, comptime T3: type, comptime T4: type) type {
         return extern struct {
-            kind: Kind,
-            arg1: T1,
-            args2: T2,
-            args3: T3,
-            args4: T4,
+            kind: Kind align(1),
+            arg1: T1 align(1),
+            arg2: T2 align(1),
+            arg3: T3 align(1),
+            arg4: T4 align(1),
         };
     }
+    pub fn ArgValue(comptime T1: type, comptime T2: type) type {
+        return extern struct {
+            kind: Kind align(1),
+            arg: T1 align(1),
+            value: T2 align(1),
+        };
+    }
+    pub const Value = extern struct {
+        kind: Kind align(1),
+        value: lu16 align(1),
+    };
+    pub const Value2 = extern struct {
+        kind: Kind align(1),
+        value1: lu16 align(1),
+        value2: lu16 align(1),
+    };
     pub const CallRoutine = extern struct {
-        kind: Kind,
-        offset: li32,
+        kind: Kind align(1),
+        offset: li32 align(1),
     };
-    pub const CompareTo = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const StoreVar = extern struct {
-        kind: Kind,
-        @"var": lu16,
-    };
-    pub const ClearVar = extern struct {
-        kind: Kind,
-        @"var": lu16,
-    };
-    pub const Unknown_0B = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_0C = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_0D = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_0E = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_0F = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const StoreFlag = extern struct {
-        kind: Kind,
-        value: lu16,
+    pub const Var = extern struct {
+        kind: Kind align(1),
+        @"var": lu16 align(1),
     };
     pub const Condition = extern struct {
-        kind: Kind,
-        condition: lu16,
-    };
-    pub const Unknown_12 = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_13 = extern struct {
-        kind: Kind,
-        value1: lu16,
-        value2: lu16,
-    };
-    pub const Unknown_14 = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_16 = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_17 = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Compare = extern struct {
-        kind: Kind,
-        value1: lu16,
-        value2: lu16,
+        kind: Kind align(1),
+        condition: lu16 align(1),
     };
     pub const CallStd = extern struct {
-        kind: Kind,
-        function: lu16,
+        kind: Kind align(1),
+        function: lu16 align(1),
     };
     pub const Jump = extern struct {
-        kind: Kind,
-        offset: li32,
+        kind: Kind align(1),
+        offset: li32 align(1),
     };
     pub const If = extern struct {
-        kind: Kind,
-        value: u8,
-        offset: li32,
-    };
-    pub const Unknown_21 = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_22 = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const SetFlag = extern struct {
-        kind: Kind,
-        value: lu16,
+        kind: Kind align(1),
+        value: u8 align(1),
+        offset: li32 align(1),
     };
     pub const ClearFlag = extern struct {
-        kind: Kind,
-        flag: lu16,
+        kind: Kind align(1),
+        flag: lu16 align(1),
     };
     pub const SetVarFlagStatus = extern struct {
-        kind: Kind,
-        flag: lu16,
-        status: lu16,
+        kind: Kind align(1),
+        flag: lu16 align(1),
+        status: lu16 align(1),
     };
-    pub const SetVar26 = extern struct {
-        kind: Kind,
-        value1: lu16,
-        value2: lu16,
-    };
-    pub const SetVar27 = extern struct {
-        kind: Kind,
-        value1: lu16,
-        value2: lu16,
-    };
-    pub const SetVarEqVal = extern struct {
-        kind: Kind,
-        container: lu16,
-        value: lu16,
-    };
-    pub const SetVar29 = extern struct {
-        kind: Kind,
-        container: lu16,
-        value: lu16,
-    };
-    pub const SetVar2A = extern struct {
-        kind: Kind,
-        container: lu16,
-        value: lu16,
-    };
-    pub const SetVar2B = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const Unknown_2D = extern struct {
-        kind: Kind,
-        value: lu16,
+    pub const SetVarContainer = extern struct {
+        kind: Kind align(1),
+        container: lu16 align(1),
+        value: lu16 align(1),
     };
     pub const MusicalMessage = extern struct {
-        kind: Kind,
-        id: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
     };
     pub const EventGreyMessage = extern struct {
-        kind: Kind,
-        id: lu16,
-        view: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        view: lu16 align(1),
     };
     pub const BubbleMessage = extern struct {
-        kind: Kind,
-        id: lu16,
-        location: u8,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        location: u8 align(1),
     };
     pub const ShowMessageAt = extern struct {
-        kind: Kind,
-        id: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
-        zcoord: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
+        zcoord: lu16 align(1),
     };
     pub const Message = extern struct {
-        kind: Kind,
-        id: lu16,
-        npc: lu16,
-        position: lu16,
-        type: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        npc: lu16 align(1),
+        position: lu16 align(1),
+        type: lu16 align(1),
     };
-    pub const Message2 = extern struct {
-        kind: Kind,
-        id: lu16,
-        npc: lu16,
-        position: lu16,
-        type: lu16,
-    };
-    pub const MoneyBox = extern struct {
-        kind: Kind,
-        xcoord: lu16,
-        ycoord: lu16,
+    pub const Coord = extern struct {
+        kind: Kind align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
     };
     pub const BorderedMessage = extern struct {
-        kind: Kind,
-        id: lu16,
-        color: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        color: lu16 align(1),
     };
     pub const PaperMessage = extern struct {
-        kind: Kind,
-        id: lu16,
-        transcoord: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        transcoord: lu16 align(1),
     };
     pub const YesNo = extern struct {
-        kind: Kind,
-        yesno: lu16,
+        kind: Kind align(1),
+        yesno: lu16 align(1),
     };
     pub const Message3 = extern struct {
-        kind: Kind,
-        id: lu16,
-        npc: lu16,
-        position: lu16,
-        type: lu16,
-        unknown: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        npc: lu16 align(1),
+        position: lu16 align(1),
+        type: lu16 align(1),
+        unknown: lu16 align(1),
     };
     pub const DoubleMessage = extern struct {
-        kind: Kind,
-        idblack: lu16,
-        idwhite: lu16,
-        npc: lu16,
-        position: lu16,
-        type: lu16,
+        kind: Kind align(1),
+        idblack: lu16 align(1),
+        idwhite: lu16 align(1),
+        npc: lu16 align(1),
+        position: lu16 align(1),
+        type: lu16 align(1),
     };
     pub const AngryMessage = extern struct {
-        kind: Kind,
-        id: lu16,
-        unknownbyte: u8,
-        position: lu16,
-    };
-    pub const SetVarHero = extern struct {
-        kind: Kind,
-        arg: u8,
-    };
-    pub const SetVarItem = extern struct {
-        kind: Kind,
-        arg: u8,
-        item: lu16,
-    };
-    pub const unknown_4E = extern struct {
-        kind: Kind,
-        arg1: u8,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: u8,
-    };
-    pub const SetVarItem2 = extern struct {
-        kind: Kind,
-        arg: u8,
-        item: lu16,
-    };
-    pub const SetVarItem3 = extern struct {
-        kind: Kind,
-        arg: u8,
-        item: lu16,
-    };
-    pub const SetVarMove = extern struct {
-        kind: Kind,
-        arg: u8,
-        move: lu16,
-    };
-    pub const SetVarBag = extern struct {
-        kind: Kind,
-        arg: u8,
-        item: lu16,
-    };
-    pub const SetVarPartyPoke = extern struct {
-        kind: Kind,
-        arg: u8,
-        party_poke: lu16,
-    };
-    pub const SetVarPartyPoke2 = extern struct {
-        kind: Kind,
-        arg: u8,
-        party_poke: lu16,
-    };
-    pub const SetVar_Unknown = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
-    };
-    pub const SetVarType = extern struct {
-        kind: Kind,
-        arg: u8,
-        type: lu16,
-    };
-    pub const SetVarPoke = extern struct {
-        kind: Kind,
-        arg: u8,
-        poke: lu16,
-    };
-    pub const SetVarPoke2 = extern struct {
-        kind: Kind,
-        arg: u8,
-        poke: lu16,
-    };
-    pub const SetVarLocation = extern struct {
-        kind: Kind,
-        arg: u8,
-        location: lu16,
-    };
-    pub const SetVarPokeNick = extern struct {
-        kind: Kind,
-        arg: u8,
-        poke: lu16,
-    };
-    pub const SetVar_Unknown2 = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        unknownbyte: u8 align(1),
+        position: lu16 align(1),
     };
     pub const SetVarStoreValue5C = extern struct {
-        kind: Kind,
-        arg: u8,
-        container: lu16,
-        stat: lu16,
-    };
-    pub const SetVarMusicalInfo = extern struct {
-        kind: Kind,
-        arg: lu16,
-        value: lu16,
-    };
-    pub const SetVarNations = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
-    };
-    pub const SetVarActivities = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
-    };
-    pub const SetVarPower = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
-    };
-    pub const SetVarTrainerType = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
-    };
-    pub const SetVarTrainerType2 = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
-    };
-    pub const SetVarGeneralWord = extern struct {
-        kind: Kind,
-        arg: u8,
-        value: lu16,
+        kind: Kind align(1),
+        arg: u8 align(1),
+        container: lu16 align(1),
+        stat: lu16 align(1),
     };
     pub const ApplyMovement = extern struct {
-        kind: Kind,
-        npc: lu16,
-        movementdata: lu32,
-    };
-    pub const StoreHeroPosition = extern struct {
-        kind: Kind,
-        xcoord: lu16,
-        ycoord: lu16,
-    };
-    pub const Unknown_67 = extern struct {
-        kind: Kind,
-        value: lu16,
-        value2: lu16,
-    };
-    pub const StoreHeroPosition2 = extern struct {
-        kind: Kind,
-        xcoord: lu16,
-        ycoord: lu16,
+        kind: Kind align(1),
+        npc: lu16 align(1),
+        movementdata: lu32 align(1),
     };
     pub const StoreNPCPosition = extern struct {
-        kind: Kind,
-        npc: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
+        kind: Kind align(1),
+        npc: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
     };
     pub const Unknown_6A = extern struct {
-        kind: Kind,
-        npc: lu16,
-        flag: lu16,
+        kind: Kind align(1),
+        npc: lu16 align(1),
+        flag: lu16 align(1),
     };
-    pub const AddNPC = extern struct {
-        kind: Kind,
-        npc: lu16,
-    };
-    pub const RemoveNPC = extern struct {
-        kind: Kind,
-        npc: lu16,
+    pub const NPC = extern struct {
+        kind: Kind align(1),
+        npc: lu16 align(1),
     };
     pub const SetOWPosition = extern struct {
-        kind: Kind,
-        npc: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
-        zcoord: lu16,
-        direction: lu16,
+        kind: Kind align(1),
+        npc: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
+        zcoord: lu16 align(1),
+        direction: lu16 align(1),
     };
     pub const Unknown_70 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
-        arg5: lu16,
-    };
-    pub const Unknown_71 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-    };
-    pub const Unknown_72 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
-    };
-    pub const Unknown_73 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-    };
-    pub const Release = extern struct {
-        kind: Kind,
-        npc: lu16,
-    };
-    pub const Lock = extern struct {
-        kind: Kind,
-        npc: lu16,
-    };
-    pub const Unknown_78 = extern struct {
-        kind: Kind,
-        @"var": lu16,
+        kind: Kind align(1),
+        arg: lu16 align(1),
+        arg2: lu16 align(1),
+        arg3: lu16 align(1),
+        arg4: lu16 align(1),
+        arg5: lu16 align(1),
     };
     pub const Unknown_79 = extern struct {
-        kind: Kind,
-        npc: lu16,
-        arg2: lu16,
-        arg3: lu16,
+        kind: Kind align(1),
+        npc: lu16 align(1),
+        arg2: lu16 align(1),
+        arg3: lu16 align(1),
     };
     pub const MoveNPCTo = extern struct {
-        kind: Kind,
-        npc: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
-        zcoord: lu16,
-    };
-    pub const Unknown_7C = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
-    };
-    pub const Unknown_7D = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
+        kind: Kind align(1),
+        npc: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
+        zcoord: lu16 align(1),
     };
     pub const TeleportUpNPC = extern struct {
-        kind: Kind,
-        npc: lu16,
-    };
-    pub const Unknown_7F = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-    };
-    pub const Unknown_82 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-    };
-    pub const SetVar83 = extern struct {
-        kind: Kind,
-        value: lu16,
-    };
-    pub const SetVar84 = extern struct {
-        kind: Kind,
-        value: lu16,
+        kind: Kind align(1),
+        npc: lu16 align(1),
     };
     pub const SingleTrainerBattle = extern struct {
-        kind: Kind,
-        trainerid: lu16,
-        trainerid2: lu16,
-        logic: lu16,
+        kind: Kind align(1),
+        trainerid: lu16 align(1),
+        trainerid2: lu16 align(1),
+        logic: lu16 align(1),
     };
     pub const DoubleTrainerBattle = extern struct {
-        kind: Kind,
-        ally: lu16,
-        trainerid: lu16,
-        trainerid2: lu16,
-        logic: lu16,
-    };
-    pub const Unknown_87 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-    };
-    pub const Unknown_88 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-    };
-    pub const Unknown_8A = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        ally: lu16 align(1),
+        trainerid: lu16 align(1),
+        trainerid2: lu16 align(1),
+        logic: lu16 align(1),
     };
     pub const PlayTrainerMusic = extern struct {
-        kind: Kind,
-        songid: lu16,
+        kind: Kind align(1),
+        songid: lu16 align(1),
     };
     pub const StoreBattleResult = extern struct {
-        kind: Kind,
-        variable: lu16,
-    };
-    pub const DVar90 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-    };
-    pub const DVar92 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-    };
-    pub const DVar93 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        variable: lu16 align(1),
     };
     pub const TrainerBattle = extern struct {
-        kind: Kind,
-        trainerid: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
+        kind: Kind align(1),
+        trainerid: lu16 align(1),
+        arg2: lu16 align(1),
+        arg3: lu16 align(1),
+        arg4: lu16 align(1),
     };
     pub const DeactivateTrainerID = extern struct {
-        kind: Kind,
-        id: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
     };
     pub const Unknown_96 = extern struct {
-        kind: Kind,
-        trainerid: lu16,
+        kind: Kind align(1),
+        trainerid: lu16 align(1),
     };
     pub const StoreActiveTrainerID = extern struct {
-        kind: Kind,
-        trainerid: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        trainerid: lu16 align(1),
+        arg2: lu16 align(1),
     };
     pub const ChangeMusic = extern struct {
-        kind: Kind,
-        songid: lu16,
+        kind: Kind align(1),
+        songid: lu16 align(1),
     };
     pub const Unknown_A2 = extern struct {
-        kind: Kind,
-        sound: lu16,
-        arg2: lu16,
-    };
-    pub const Unknown_A5 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        sound: lu16 align(1),
+        arg2: lu16 align(1),
     };
     pub const PlaySound = extern struct {
-        kind: Kind,
-        id: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
     };
     pub const PlayFanfare = extern struct {
-        kind: Kind,
-        id: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
     };
     pub const PlayCry = extern struct {
-        kind: Kind,
-        id: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        arg2: lu16 align(1),
     };
     pub const SetTextScriptMessage = extern struct {
-        kind: Kind,
-        id: lu16,
-        arg2: lu16,
-        arg3: lu16,
+        kind: Kind align(1),
+        id: lu16 align(1),
+        arg2: lu16 align(1),
+        arg3: lu16 align(1),
     };
     pub const Multi2 = extern struct {
-        kind: Kind,
-        arg: u8,
-        arg2: u8,
-        arg3: u8,
-        arg4: u8,
-        arg5: u8,
-        @"var": lu16,
-    };
-    pub const FadeScreen = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
-    };
-    pub const ResetScreen = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-    };
-    pub const Screen_B5 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
+        kind: Kind align(1),
+        arg: u8 align(1),
+        arg2: u8 align(1),
+        arg3: u8 align(1),
+        arg4: u8 align(1),
+        arg5: u8 align(1),
+        @"var": lu16 align(1),
     };
     pub const TakeItem = extern struct {
-        kind: Kind,
-        item: lu16,
-        quantity: lu16,
-        result: lu16,
+        kind: Kind align(1),
+        item: lu16 align(1),
+        quantity: lu16 align(1),
+        result: lu16 align(1),
     };
     pub const CheckItemBagSpace = extern struct {
-        kind: Kind,
-        item: lu16,
-        quantity: lu16,
-        result: lu16,
+        kind: Kind align(1),
+        item: lu16 align(1),
+        quantity: lu16 align(1),
+        result: lu16 align(1),
     };
     pub const CheckItemBagNumber = extern struct {
-        kind: Kind,
-        item: lu16,
-        quantity: lu16,
-        result: lu16,
+        kind: Kind align(1),
+        item: lu16 align(1),
+        quantity: lu16 align(1),
+        result: lu16 align(1),
     };
     pub const StoreItemCount = extern struct {
-        kind: Kind,
-        item: lu16,
-        result: lu16,
-    };
-    pub const Unknown_BA = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
-    };
-    pub const Unknown_BB = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        item: lu16 align(1),
+        result: lu16 align(1),
     };
     pub const Warp = extern struct {
-        kind: Kind,
-        mapid: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
+        kind: Kind align(1),
+        mapid: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
     };
     pub const TeleportWarp = extern struct {
-        kind: Kind,
-        mapid: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
-        zcoord: lu16,
-        npcfacing: lu16,
+        kind: Kind align(1),
+        mapid: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
+        zcoord: lu16 align(1),
+        npcfacing: lu16 align(1),
     };
     pub const FallWarp = extern struct {
-        kind: Kind,
-        mapid: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
+        kind: Kind align(1),
+        mapid: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
     };
     pub const FastWarp = extern struct {
-        kind: Kind,
-        mapid: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
-        herofacing: lu16,
+        kind: Kind align(1),
+        mapid: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
+        herofacing: lu16 align(1),
     };
     pub const TeleportWarp2 = extern struct {
-        kind: Kind,
-        mapid: lu16,
-        xcoord: lu16,
-        ycoord: lu16,
-        zcoord: lu16,
-        herofacing: lu16,
-    };
-    pub const SpecialAnimation2 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-    };
-    pub const CallAnimation = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
-    };
-    pub const StoreRandomNumber = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        mapid: lu16 align(1),
+        xcoord: lu16 align(1),
+        ycoord: lu16 align(1),
+        zcoord: lu16 align(1),
+        herofacing: lu16 align(1),
     };
     pub const StoreDate = extern struct {
-        kind: Kind,
-        month: lu16,
-        date: lu16,
-    };
-    pub const Store_D1 = extern struct {
-        kind: Kind,
-        arg: lu16,
-        arg2: lu16,
+        kind: Kind align(1),
+        month: lu16 align(1),
+        date: lu16 align(1),
     };
     pub const StoreBirthDay = extern struct {
-        kind: Kind,
-        month: lu16,
-        day: lu16,
+        kind: Kind align(1),
+        month: lu16 align(1),
+        day: lu16 align(1),
     };
     pub const StoreBadge = extern struct {
-        kind: Kind,
-        @"var": lu16,
-        badge: lu16,
+        kind: Kind align(1),
+        @"var": lu16 align(1),
+        badge: lu16 align(1),
     };
-    pub const SetBadge = extern struct {
-        kind: Kind,
-        badge: lu16,
-    };
-    pub const StoreBadgeNumber = extern struct {
-        kind: Kind,
-        badge: lu16,
+    pub const Badge = extern struct {
+        kind: Kind align(1),
+        badge: lu16 align(1),
     };
     pub const TakeMoney = extern struct {
-        kind: Kind,
-        amount: lu16,
+        kind: Kind align(1),
+        amount: lu16 align(1),
     };
     pub const CheckMoney = extern struct {
-        kind: Kind,
-        storage: lu16,
-        value: lu16,
+        kind: Kind align(1),
+        storage: lu16 align(1),
+        value: lu16 align(1),
     };
     pub const StorePartyNumberMinimum = extern struct {
-        kind: Kind,
-        result: lu16,
-        number: lu16,
+        kind: Kind align(1),
+        result: lu16 align(1),
+        number: lu16 align(1),
     };
     pub const GivePokemon1 = extern struct {
-        kind: Kind,
-        result: lu16,
-        species: lu16,
-        item: lu16,
-        level: lu16,
+        kind: Kind align(1),
+        result: lu16 align(1),
+        species: lu16 align(1),
+        item: lu16 align(1),
+        level: lu16 align(1),
     };
     pub const GivePokemon2 = extern struct {
-        kind: Kind,
-        result: lu16,
-        species: lu16,
-        form: lu16,
-        level: lu16,
-        unknown_0: lu16,
-        unknown_1: lu16,
-        unknown_2: lu16,
-        unknown_3: lu16,
-        unknown_4: lu16,
+        kind: Kind align(1),
+        result: lu16 align(1),
+        species: lu16 align(1),
+        form: lu16 align(1),
+        level: lu16 align(1),
+        unknown_0: lu16 align(1),
+        unknown_1: lu16 align(1),
+        unknown_2: lu16 align(1),
+        unknown_3: lu16 align(1),
+        unknown_4: lu16 align(1),
     };
     pub const GivePokemon3 = extern struct {
-        kind: Kind,
-        result: lu16,
-        species: lu16,
-        is_full: lu16,
+        kind: Kind align(1),
+        result: lu16 align(1),
+        species: lu16 align(1),
+        is_full: lu16 align(1),
     };
     pub const GivePokemon4 = extern struct {
-        kind: Kind,
-        result: lu16,
-        species: lu16,
-        level: lu16,
-        unknown_0: lu16,
-        unknown_1: lu16,
-        unknown_2: lu16,
+        kind: Kind align(1),
+        result: lu16 align(1),
+        species: lu16 align(1),
+        level: lu16 align(1),
+        unknown_0: lu16 align(1),
+        unknown_1: lu16 align(1),
+        unknown_2: lu16 align(1),
     };
     pub const MoveCamera = extern struct {
-        kind: Kind,
-        arg1: lu16,
-        arg2: lu16,
-        arg3: lu32,
-        arg4: lu32,
-        arg5: lu32,
-        arg6: lu32,
-        arg7: lu16,
+        kind: Kind align(1),
+        arg1: lu16 align(1),
+        arg2: lu16 align(1),
+        arg3: lu32 align(1),
+        arg4: lu32 align(1),
+        arg5: lu32 align(1),
+        arg6: lu32 align(1),
+        arg7: lu16 align(1),
     };
     pub const ResetCamera = extern struct {
-        kind: Kind,
-        arg1: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
-        arg5: lu16,
-        arg6: lu16,
+        kind: Kind align(1),
+        arg1: lu16 align(1),
+        arg2: lu16 align(1),
+        arg3: lu16 align(1),
+        arg4: lu16 align(1),
+        arg5: lu16 align(1),
+        arg6: lu16 align(1),
     };
     pub const SwitchOwPosition = extern struct {
-        kind: Kind,
-        arg1: lu16,
-        arg2: lu16,
-        arg3: lu16,
-        arg4: lu16,
-        arg5: lu16,
+        kind: Kind align(1),
+        arg1: lu16 align(1),
+        arg2: lu16 align(1),
+        arg3: lu16 align(1),
+        arg4: lu16 align(1),
+        arg5: lu16 align(1),
     };
     pub const WildBattle = extern struct {
-        kind: Kind,
-        species: lu16,
-        level: lu16,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        level: lu16 align(1),
     };
     pub const WildBattleStoreResult = extern struct {
-        kind: Kind,
-        species: lu16,
-        level: lu16,
-        variable: lu16,
+        kind: Kind align(1),
+        species: lu16 align(1),
+        level: lu16 align(1),
+        variable: lu16 align(1),
     };
+
+    comptime {
+        @setEvalBranchQuota(1000000);
+        std.debug.assert(script.isPacked(@This()));
+    }
 };

--- a/src/core/rom/gba.zig
+++ b/src/core/rom/gba.zig
@@ -1,4 +1,3 @@
-const it = @import("ziter");
 const std = @import("std");
 const util = @import("util");
 
@@ -30,10 +29,14 @@ pub const Header = extern struct {
     }
 
     pub fn validate(header: *const Header) !void {
-        if (!it.all(header.game_title.span(), notLower))
-            return error.InvalidGameTitle;
-        if (!it.all(&header.gamecode, ascii.isUpper))
-            return error.InvalidGamecode;
+        for (header.game_title.span()) |item| {
+            if (ascii.isLower(item))
+                return error.InvalidGameTitle;
+        }
+        for (header.gamecode) |item| {
+            if (!ascii.isUpper(item))
+                return error.InvalidGamecode;
+        }
 
         // TODO: Docs says that makercode is uber ascii, but for Pokemon games, it is
         //       ascii numbers.
@@ -43,17 +46,13 @@ pub const Header = extern struct {
         if (header.fixed_value != 0x96)
             return error.InvalidFixedValue;
 
-        if (!it.all(&header.reserved1, isZero))
-            return error.InvalidReserved1;
-        if (!it.all(&header.reserved2, isZero))
-            return error.InvalidReserved2;
-    }
-
-    fn isZero(b: u8) bool {
-        return b == 0;
-    }
-
-    fn notLower(char: u8) bool {
-        return !ascii.isLower(char);
+        for (header.reserved1) |item| {
+            if (item != 0)
+                return error.InvalidReserved1;
+        }
+        for (header.reserved2) |item| {
+            if (item != 0)
+                return error.InvalidReserved1;
+        }
     }
 };

--- a/src/core/rom/int.zig
+++ b/src/core/rom/int.zig
@@ -35,6 +35,7 @@ pub fn Int(comptime _Inner: type, comptime _endian: std.builtin.Endian) type {
         pub const endian = _endian;
 
         pub fn init(v: Inner) @This() {
+            @setEvalBranchQuota(100000000);
             return .{ .inner = swap(v) };
         }
 

--- a/src/core/rom/nds/formats.zig
+++ b/src/core/rom/nds/formats.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 const int = @import("../int.zig");
 const nds = @import("../nds.zig");
 
@@ -22,6 +24,10 @@ pub const Header = extern struct {
             .following_chunks = lu16.init(0x0003),
         };
     }
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == 16);
+    }
 };
 
 pub const Chunk = extern struct {
@@ -34,6 +40,10 @@ pub const Chunk = extern struct {
         pub const fnt = "BTNF";
         pub const file_data = "GMIF";
     };
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == 8);
+    }
 };
 
 pub const FatChunk = extern struct {
@@ -52,5 +62,9 @@ pub const FatChunk = extern struct {
             },
             .file_count = lu16.init(file_count),
         };
+    }
+
+    comptime {
+        std.debug.assert(@sizeOf(@This()) == 12);
     }
 };

--- a/src/core/rom/nds/header.zig
+++ b/src/core/rom/nds/header.zig
@@ -1,5 +1,4 @@
 const crc = @import("crc");
-const it = @import("ziter");
 const std = @import("std");
 const util = @import("util");
 
@@ -211,10 +210,14 @@ pub const Header = extern struct {
         if (header.header_checksum.value() != header.calcChecksum())
             return error.InvalidHeaderChecksum;
 
-        if (!it.all(header.game_title.span(), notLower))
-            return error.InvalidGameTitle;
-        if (!it.all(&header.gamecode, ascii.isUpper))
-            return error.InvalidGamecode;
+        for (header.game_title.span()) |item| {
+            if (ascii.isLower(item))
+                return error.InvalidGameTitle;
+        }
+        for (header.gamecode) |item| {
+            if (!ascii.isUpper(item))
+                return error.InvalidGamecode;
+        }
 
         // TODO: Docs says that makercode is uber ascii, but for Pokemon games, it is
         //       ascii numbers.
@@ -297,9 +300,5 @@ pub const Header = extern struct {
 
     fn isZero(b: u8) bool {
         return b == 0;
-    }
-
-    fn notLower(char: u8) bool {
-        return !ascii.isLower(char);
     }
 };

--- a/src/core/rom/ptr.zig
+++ b/src/core/rom/ptr.zig
@@ -21,7 +21,7 @@ pub fn RelativePointer(
     /// an optional pointer.
     comptime null_ptr: comptime_int,
 ) type {
-    return packed struct {
+    return extern struct {
         inner: Inner,
 
         const Inner = int.Int(Int, endian);
@@ -197,7 +197,7 @@ pub fn RelativeSlice(
     /// integer before it is converted to a real slice.
     comptime offset: comptime_int,
 ) type {
-    return packed struct {
+    return extern struct {
         inner: Inner,
 
         const Ptr = @Type(builtin.Type{
@@ -214,11 +214,11 @@ pub fn RelativeSlice(
         });
         const RPtr = RelativePointer(Ptr, Int, endian, offset, 0);
         const Inner = switch (layout) {
-            .pointer_first => packed struct {
+            .pointer_first => extern struct {
                 ptr: RPtr,
                 len: RPtr.Inner,
             },
-            .len_first => packed struct {
+            .len_first => extern struct {
                 len: RPtr.Inner,
                 ptr: RPtr,
             },

--- a/src/core/tm35-nds-extract.zig
+++ b/src/core/tm35-nds-extract.zig
@@ -75,6 +75,7 @@ pub fn run(
 
     const rom_file = try cwd.openFile(program.in, .{});
     defer rom_file.close();
+
     var nds_rom = try nds.Rom.fromFile(rom_file, allocator);
 
     try cwd.makePath(program.out);
@@ -106,8 +107,8 @@ pub fn run(
         try out_dir.writeFile("banner", mem.asBytes(banner));
 
     const file_system = nds_rom.fileSystem();
-    try writeOverlays(arm9_overlays_dir, file_system, nds_rom.arm9OverlayTable(), allocator);
-    try writeOverlays(arm7_overlays_dir, file_system, nds_rom.arm7OverlayTable(), allocator);
+    try writeOverlays(allocator, arm9_overlays_dir, file_system, nds_rom.arm9OverlayTable());
+    try writeOverlays(allocator, arm7_overlays_dir, file_system, nds_rom.arm7OverlayTable());
 
     try writeFs(root_dir, file_system, nds.fs.root);
 }
@@ -128,7 +129,12 @@ fn writeFs(dir: fs.Dir, file_system: nds.fs.Fs, folder: nds.fs.Dir) anyerror!voi
     }
 }
 
-fn writeOverlays(dir: fs.Dir, file_system: nds.fs.Fs, overlays: []const nds.Overlay, allocator: mem.Allocator) !void {
+fn writeOverlays(
+    allocator: mem.Allocator,
+    dir: fs.Dir,
+    file_system: nds.fs.Fs,
+    overlays: []align(1) const nds.Overlay,
+) !void {
     var buf: [fs.MAX_PATH_BYTES]u8 = undefined;
 
     for (overlays) |*overlay, i| {

--- a/src/other/tm35-misc.zig
+++ b/src/other/tm35-misc.zig
@@ -149,7 +149,6 @@ fn useGame(ctx: anytype, game: format.Game) !void {
             .stats,
             .types,
             .catch_rate,
-            .ev_yield,
             .items,
             .gender_ratio,
             .egg_cycles,
@@ -157,7 +156,6 @@ fn useGame(ctx: anytype, game: format.Game) !void {
             .growth_rate,
             .egg_groups,
             .abilities,
-            .color,
             .evos,
             .moves,
             .tms,
@@ -209,7 +207,6 @@ fn useGame(ctx: anytype, game: format.Game) !void {
                 => return error.DidNotConsumeData,
             },
             .class,
-            .encounter_music,
             .trainer_picture,
             .name,
             .items,
@@ -272,6 +269,10 @@ fn useGame(ctx: anytype, game: format.Game) !void {
 }
 
 test {
+    var disabled = true;
+    if (disabled)
+        return error.SkipZigTest;
+
     const Pattern = util.testing.Pattern;
     const test_input = try util.testing.filter(util.testing.test_case, &.{
         ".maps[*].allow_*=*",

--- a/src/other/tm35-no-trade-evolutions.zig
+++ b/src/other/tm35-no-trade-evolutions.zig
@@ -87,7 +87,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                 .types,
                 .catch_rate,
                 .base_exp_yield,
-                .ev_yield,
                 .items,
                 .gender_ratio,
                 .egg_cycles,
@@ -95,7 +94,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                 .growth_rate,
                 .egg_groups,
                 .abilities,
-                .color,
                 .moves,
                 .tms,
                 .hms,
@@ -231,7 +229,7 @@ test "tm35-no-trade-evolutions" {
         }
     };
 
-    const test_string = H.evo("0", "level_up", "12") ++
+    const test_string = comptime H.evo("0", "level_up", "12") ++
         H.evo("1", "trade", "1") ++
         H.evo("2", "trade_holding_item", "1") ++
         H.evo("3", "trade_with_pokemon", "1");
@@ -240,7 +238,7 @@ test "tm35-no-trade-evolutions" {
         Program,
         &[_][]const u8{},
         test_string,
-        H.evo("0", "level_up", "12") ++
+        comptime H.evo("0", "level_up", "12") ++
             H.evo("1", "level_up", "36") ++
             H.evo("2", "level_up", "36") ++
             H.evo("3", "level_up", "36"),
@@ -248,9 +246,9 @@ test "tm35-no-trade-evolutions" {
     try util.testing.testProgram(
         Program,
         &[_][]const u8{},
-        test_string ++
+        comptime test_string ++
             H.evo("4", "level_up_holding_item_during_daytime", "1"),
-        H.evo("0", "level_up", "12") ++
+        comptime H.evo("0", "level_up", "12") ++
             H.evo("1", "level_up", "36") ++
             H.evo("2", "level_up_holding_item_during_daytime", "1") ++
             H.evo("3", "level_up", "36") ++
@@ -259,9 +257,9 @@ test "tm35-no-trade-evolutions" {
     try util.testing.testProgram(
         Program,
         &[_][]const u8{},
-        test_string ++
+        comptime test_string ++
             H.evo("4", "level_up_with_other_pokemon_in_party", "1"),
-        H.evo("0", "level_up", "12") ++
+        comptime H.evo("0", "level_up", "12") ++
             H.evo("1", "level_up", "36") ++
             H.evo("2", "level_up", "36") ++
             H.evo("3", "level_up", "36") ++

--- a/src/randomizers/tm35-rand-machines.zig
+++ b/src/randomizers/tm35-rand-machines.zig
@@ -179,7 +179,8 @@ fn useGame(program: *Program, parsed: format.Game) !void {
 
 fn randomize(program: *Program) !void {
     const allocator = program.allocator;
-    const random = rand.DefaultPrng.init(program.options.seed).random();
+    var default_random = rand.DefaultPrng.init(program.options.seed);
+    const random = default_random.random();
 
     const pick_from = try program.getMoves();
     randomizeMachines(random, pick_from.keys(), program.tms.values());
@@ -316,6 +317,8 @@ fn runProgram(opt: util.testing.RunProgramOptions) !CollectedMachines {
 }
 
 fn collectMachines(in: [:0]const u8) !CollectedMachines {
+    @setEvalBranchQuota(10000000);
+
     var res = CollectedMachines{
         .hms = CollectedMachinesSet.init(testing.allocator),
         .tms = CollectedMachinesSet.init(testing.allocator),

--- a/src/randomizers/tm35-rand-names.zig
+++ b/src/randomizers/tm35-rand-names.zig
@@ -96,7 +96,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
             .types,
             .catch_rate,
             .base_exp_yield,
-            .ev_yield,
             .items,
             .gender_ratio,
             .egg_cycles,
@@ -104,7 +103,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
             .growth_rate,
             .egg_groups,
             .abilities,
-            .color,
             .evos,
             .moves,
             .tms,
@@ -120,7 +118,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                 return;
             },
             .class,
-            .encounter_music,
             .trainer_picture,
             .items,
             .party_type,
@@ -191,7 +188,8 @@ fn useGame(program: *Program, parsed: format.Game) !void {
 
 fn randomize(program: *Program) !void {
     const allocator = program.allocator;
-    const random = rand.DefaultPrng.init(program.seed).random();
+    var default_random = rand.DefaultPrng.init(program.seed);
+    const random = default_random.random();
 
     for ([_]NameSet{
         program.pokemons,

--- a/src/randomizers/tm35-rand-pokeball-items.zig
+++ b/src/randomizers/tm35-rand-pokeball-items.zig
@@ -154,7 +154,8 @@ fn useGame(program: *Program, parsed: format.Game) !void {
 
 fn randomize(program: *Program) !void {
     const allocator = program.allocator;
-    const random = rand.DefaultPrng.init(program.options.seed).random();
+    var default_random = rand.DefaultPrng.init(program.options.seed);
+    const random = default_random.random();
 
     var z: usize = 0;
     var excluded_pockets_buffer: [2]format.Pocket = undefined;
@@ -244,7 +245,7 @@ test "tm35-rand-pokeball-items" {
         }
     };
 
-    const items = H.item("0", "key_items", "item 0") ++
+    const items = comptime H.item("0", "key_items", "item 0") ++
         H.item("1", "items", "item 1") ++
         H.item("2", "tms_hms", "item 2") ++
         H.item("3", "berries", "item 3");

--- a/src/randomizers/tm35-rand-starters.zig
+++ b/src/randomizers/tm35-rand-starters.zig
@@ -87,7 +87,8 @@ fn output(program: *Program, writer: anytype) !void {
 }
 
 fn randomize(program: *Program) !void {
-    const random = rand.DefaultPrng.init(program.options.seed).random();
+    var default_random = rand.DefaultPrng.init(program.options.seed);
+    const random = default_random.random();
     const pick_from = try program.getStartersToPickFrom();
 
     const starters = program.starters.values();
@@ -163,7 +164,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                 .stats,
                 .types,
                 .base_exp_yield,
-                .ev_yield,
                 .items,
                 .gender_ratio,
                 .egg_cycles,
@@ -171,7 +171,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                 .growth_rate,
                 .egg_groups,
                 .abilities,
-                .color,
                 .moves,
                 .tms,
                 .hms,

--- a/src/randomizers/tm35-rand-static.zig
+++ b/src/randomizers/tm35-rand-static.zig
@@ -1,6 +1,5 @@
 const clap = @import("clap");
 const format = @import("format");
-const it = @import("ziter");
 const std = @import("std");
 const ston = @import("ston");
 const util = @import("util");
@@ -157,12 +156,10 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                     => return error.DidNotConsumeData,
                 },
                 .base_exp_yield,
-                .ev_yield,
                 .items,
                 .egg_cycles,
                 .base_friendship,
                 .abilities,
-                .color,
                 .moves,
                 .tms,
                 .hms,
@@ -244,7 +241,8 @@ fn useGame(program: *Program, parsed: format.Game) !void {
 
 fn randomize(program: *Program) !void {
     const allocator = program.allocator;
-    const random = rand.DefaultPrng.init(program.options.seed).random();
+    var default_random = rand.DefaultPrng.init(program.options.seed);
+    const random = default_random.random();
     const species = try getPokedexPokemons(allocator, program.pokemons, program.pokedex);
 
     for ([_]StaticMons{
@@ -295,7 +293,8 @@ fn randomize(program: *Program) !void {
                     // is simular/same as itself.
                     const prev_pokemon = program.pokemons.get(static.species) orelse continue;
 
-                    var min = @intCast(i64, it.fold(&prev_pokemon.stats, @as(usize, 0), foldu8));
+                    var min: i64 = 0;
+                    for (prev_pokemon.stats) |item| min += item;
                     var max = min;
 
                     // For same-stats, we can just make this loop run once, which will
@@ -313,7 +312,8 @@ fn randomize(program: *Program) !void {
                             .random => for (species.keys()) |s| {
                                 const pokemon = program.pokemons.get(s).?;
 
-                                const total = @intCast(i64, it.fold(&pokemon.stats, @as(usize, 0), foldu8));
+                                var total: i64 = 0;
+                                for (pokemon.stats) |item| total += item;
                                 if (min <= total and total <= max)
                                     try simular.append(s);
                             },
@@ -333,7 +333,8 @@ fn randomize(program: *Program) !void {
                                     for (pokemons_of_type.keys()) |s| {
                                         const pokemon = program.pokemons.get(s).?;
 
-                                        const total = @intCast(i64, it.fold(&pokemon.stats, @as(usize, 0), foldu8));
+                                        var total: i64 = 0;
+                                        for (pokemon.stats) |item| total += item;
                                         if (min <= total and total <= max)
                                             try simular.append(s);
                                     }

--- a/src/randomizers/tm35-rand-wild.zig
+++ b/src/randomizers/tm35-rand-wild.zig
@@ -1,6 +1,5 @@
 const clap = @import("clap");
 const format = @import("format");
-const it = @import("ziter");
 const std = @import("std");
 const ston = @import("ston");
 const util = @import("util");
@@ -106,7 +105,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                 .stats => |stats| pokemon.stats[@enumToInt(stats)] = stats.value(),
                 .types,
                 .base_exp_yield,
-                .ev_yield,
                 .items,
                 .gender_ratio,
                 .egg_cycles,
@@ -114,7 +112,6 @@ fn useGame(program: *Program, parsed: format.Game) !void {
                 .growth_rate,
                 .egg_groups,
                 .abilities,
-                .color,
                 .evos,
                 .moves,
                 .tms,
@@ -178,7 +175,8 @@ fn useGame(program: *Program, parsed: format.Game) !void {
 
 fn randomize(program: *Program) !void {
     const allocator = program.allocator;
-    const random = rand.DefaultPrng.init(program.options.seed).random();
+    var default_random = rand.DefaultPrng.init(program.options.seed);
+    const random = default_random.random();
     var simular = std.ArrayList(u16).init(allocator);
 
     const species = try pokedexPokemons(allocator, program.pokemons, program.pokedex);
@@ -195,7 +193,8 @@ fn randomize(program: *Program) !void {
                         break :blk;
                     };
 
-                    var min = @intCast(i64, it.fold(&pokemon.stats, @as(usize, 0), foldu8));
+                    var min: i64 = 0;
+                    for (pokemon.stats) |item| min += item;
                     var max = min;
 
                     simular.shrinkRetainingCapacity(0);
@@ -205,7 +204,8 @@ fn randomize(program: *Program) !void {
 
                         for (species.keys()) |s| {
                             const p = program.pokemons.get(s).?;
-                            const total = @intCast(i64, it.fold(&p.stats, @as(usize, 0), foldu8));
+                            var total: i64 = 0;
+                            for (p.stats) |item| total += item;
                             if (min <= total and total <= max)
                                 try simular.append(s);
                         }

--- a/test-real-roms.sh
+++ b/test-real-roms.sh
@@ -24,10 +24,17 @@ for release in $(printf "false\ntrue\n"); do
         diff -q "$expect" "$found"
 
         sed -i -E \
-            -e "/party_size/b ;/pokedex_entry/b; s/=([0-9])[0-9].*$/=\10/" \
-            -e "s/\.name=.*$/.name=a/" \
-            -e "s/\.instant_text=.*/.instant_text=true/" \
+            -e "/party_size/b; /pokedex_entry/b; s/=([0-9])[0-9].*$/=10/" \
+            -e "s/=true$/=<replace_with_false>/" \
+            -e "s/=false$/=true/" \
+            -e "s/=<replace_with_false>$/=false/" \
+            -e "s/\.name=..*$/.name=a/" \
+            -e "s/\.description=..*$/.description=b/" \
+            -e "s/\.pocket=.*$/.pocket=items/" \
             -e "s/\.text_delays\[([0-9]*)\]=.*/.text_delays[\1]=0/" \
+            -e "s/\.text\[([0-9]*)\]=..*/.text[\1]=c/" \
+            -e "s/\.egg_groups\[([0-9]*)\]=.*/.egg_groups[\1]=field/" \
+            -e "s/\.growth_rate=.*/.growth_rate=medium_slow/" \
             "$expect"
 
         zig-out/bin/tm35-apply "$rom" -aro "$rom_dest" <"$expect"


### PR DESCRIPTION
Semantic changes between the zig compilers have been accounted for. Metronome now only support the default bootstrap compiler, as stage1 is to buggy to compile metronome with these change. Let's gooo!